### PR TITLE
use bootstrap if installed; fallback:rtd, default

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,21 @@
 import os
 import sys
 
+try:
+    # use bootstrap theme if user has it installed
+    import sphinx_bootstrap_theme
+    HTML_THEME = 'bootstrap'
+    html_theme_path = [sphinx_bootstrap_theme.get_html_theme_path()]
+except ImportError:
+    try:
+        # fall back to sphinx_rtd_theme if available
+        import sphinx_rtd_theme
+        HTML_THEME = 'sphinx_rtd_theme'
+        html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+    except ImportError:
+        # and fall back to 'default' if neither of those are available
+        HTML_THEME = 'default'
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -110,7 +125,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = HTML_THEME
 
 # 1.3.1 sphinx READTHEDOCS build compat
 # SEE:


### PR DESCRIPTION
pulled and applied against master.

IF bootstrap is installed, use it; otherwise use rtd_theme (comes with sphinx in 1.3) and fallback to 'default' if neither is available