### PR TITLE
mr.bob template to generate new default plugin

### DIFF
--- a/bobtemplates/hooks.py
+++ b/bobtemplates/hooks.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# coding: utf-8
+# Author: "Chris Ward" <cward@redhat.com>
+
+'''
+Mr.Bob Hooks
+
+src: http://mrbob.readthedocs.org/en/latest/api.html#module-mrbob.hooks
+'''
+
+
+def pre_render(configurator):
+    pass
+
+
+def post_render(configurator):
+    # remove unnecessary __init__.py, hooks.py
+    pass
+
+
+def pre_ask_question(configurator, question):
+    pass
+
+
+def post_ask_question(configurator, question, answer):
+    pass
+
+
+def set_name_email(configurator, question, answer):
+    '''
+    prepare "Full Name" <email@eg.com>" string
+    '''
+    name = configurator.variables['author.name']
+    configurator.variables['author.name_email'] = '"{0}" <{1}>'.format(
+        name, answer)
+    return answer

--- a/bobtemplates/plugin/.mrbob.ini
+++ b/bobtemplates/plugin/.mrbob.ini
@@ -1,0 +1,36 @@
+[questions]
+
+plugin.name.question = Name of the plugin (one word; lower-case)
+plugin.name.required = True
+plugin.name.help = Should be something like 'rh_bugzilla'.
+
+plugin.app.question = Name of the App (CamelCase)
+plugin.app.required = True
+plugin.app.help = Should be something like 'RedHatBugzilla'.
+
+plugin.target.question = Name of the object acted on (CamelCase)
+plugin.target.required = True
+plugin.target.help = Should be something like 'Bug'
+
+plugin.verb.question = Activity verb (one word; CamelCase; past-tense)
+plugin.verb.required = True
+plugin.verb.help = Should be something like 'saved' or 'filed' or 'sent'
+
+plugin.sort_order.question = What sort order to set for this plugin?
+plugin.sort_order.required = False
+plugin.sort_order.help = Should be an integer above (default: 500)
+plugin.sort_order.default = 500
+plugin.sort_order.post_ask_question = mrbob.hooks:to_integer
+
+author.name.question = What is your full name?
+author.name.required = True
+
+author.email.question = What is your email address?
+author.email.required = True
+author.email.post_ask_question = bobtemplates.hooks:set_name_email
+
+
+[template]
+
+post_render = bobtemplates.hooks:post_render
+pre_render = bobtemplates.hooks:pre_render

--- a/bobtemplates/plugin/did/plugins/+plugin.name+.py.bob
+++ b/bobtemplates/plugin/did/plugins/+plugin.name+.py.bob
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# coding: utf-8
+# Author: {{{author.name_email}}}
+
+from __future__ import unicode_literals, absolute_import
+
+"""
+{{{plugin.app}}} stats
+
+Config example::
+
+    [{{{plugin.name}}}]
+    type = {{{plugin.name}}}
+    # more config options
+"""
+
+from did.base import Stats, StatsGroup
+from did.utils import Config, item
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  {{{plugin.app}}} Investigator
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class {{{plugin.app}}}{{{plugin.target}}}(object):
+    """ {{{plugin.app}}} {{{plugin.target}}} investigator """
+
+    def __init__(self, **kwargs):
+        """ Initialize {{{plugin.target}}} """
+        self.record = 'Testing ONE TWO THREE'
+
+    def __unicode__(self):
+        """ Summary for displaying """
+        return "{0}".format(self.record)
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  {{{plugin.app}}} Stats
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class {{{plugin.target}}}{{{plugin.verb}}}(Stats):
+    """ {{{plugin.app}}} changes """
+    def __init__(self, option='cards', name=None, parent=None):
+        super({{{plugin.target}}}{{{plugin.verb}}}, self).__init__(option, name, parent)
+
+    def fetch(self):
+        if self.option == 'cards':
+           self.stats.append('CARD #X: DONE')
+        else:
+           self.stats.append('UNKNOWN: UNKNOWN')
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  {{{plugin.app}}} Stats Group
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class {{{plugin.app}}}Stats(StatsGroup):
+    """ {{{plugin.app}}} aggregated stats """
+
+    # Default order
+    order = {{{plugin.sort_order}}}
+
+    def __init__(self, option, name=None, parent=None):
+        super({{{plugin.app}}}Stats, self).__init__(option, name, parent)
+        self.stats.append(
+	    {{{plugin.target}}}{{{plugin.verb}}}(parent=self)
+	)

--- a/bobtemplates/plugin/tests/test_plugins/test_+plugin.name+.py.bob
+++ b/bobtemplates/plugin/tests/test_plugins/test_+plugin.name+.py.bob
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+# coding: utf-8
+# Author: "{{{author.name}}}" <{{{author.email}}}>
+
+from __future__ import unicode_literals, absolute_import
+
+from did import utils
+
+
+def test_{{{plugin.app}}}{{{plugin.target}}}():
+    from did.plugins.{{{plugin.name}}} import {{{plugin.app}}}{{{plugin.target}}}
+    assert {{{plugin.app}}}{{{plugin.target}}}
+    _str = 'Testing ONE TWO THREE'
+    assert unicode({{{plugin.app}}}{{{plugin.target}}}()) == _str
+
+
+def test_{{{plugin.target}}}{{{plugin.verb}}}():
+    from did.plugins.{{{plugin.name}}} import {{{plugin.target}}}{{{plugin.verb}}}
+    assert {{{plugin.target}}}{{{plugin.verb}}}
+
+
+def test_{{{plugin.app}}}Stats():
+    from did.plugins.{{{plugin.name}}} import {{{plugin.app}}}Stats
+    assert {{{plugin.app}}}Stats


### PR DESCRIPTION
src: https://mrbob.readthedocs.org/en/latest/

Usage::
    mrbob $GITREPO/bobtemplates/plugin -O $GITREPO [-c ~/.mrbob.ini]

Where bobtemplate/plugin is the basedir for the plugin templates; all
files here will be copied there after variable replacement. `mrbob`
will ask questions to fill in variable values. You can save values
use into a mrbob.ini file and use that instead for non-interactive use.

The resulting plugin even comes with some default tests.

We'll want to add additional docs strings to the plugin to give helpful
hints to the developers and maybe include addition methods that can be
overridden with examples, etc.

But for now, this is helpful as-is