### PR TITLE
Skip CI users

### DIFF
--- a/did/plugins/gerrit.py
+++ b/did/plugins/gerrit.py
@@ -274,9 +274,14 @@ class AddedPatches(GerritUnit):
                 # patch setts added by the owner of the change, but
                 # I don’t know how to find a list of all revisions for
                 # the particular change.
-                if 'author' in chg and owner == chg['author']['email'] and \
-                    self.get_gerrit_date(chg['date'][:10]) >= self.since_date \
-                        and 'uploaded patch' in chg['message'].lower():
+                if 'author' not in chg:
+                    continue
+                if 'email' not in chg['author']:
+                    continue
+                date = self.get_gerrit_date(chg['date'][:10])
+                if (owner == chg['author']['email'] and
+                        date >= self.since_date and
+                        'uploaded patch' in chg['message'].lower()):
                     cmnts_by_user.append(chg)
             if len(cmnts_by_user) > 0:
                 self.stats.append(
@@ -316,7 +321,11 @@ class ReviewedChanges(GerritUnit):
                 pretty(changes['messages'])))
             cmnts_by_user = []
             for chg in changes['messages']:
-                if 'author' in chg and reviewer in chg['author']['email']:
+                if 'author' not in chg:
+                    continue
+                if 'email' not in chg['author']:
+                    continue
+                if reviewer in chg['author']['email']:
                     comment_date = self.get_gerrit_date(chg['date'][:10])
                     if comment_date >= self.since_date:
                         cmnts_by_user.append(chg)


### PR DESCRIPTION
This patch fixes issue when gerrit patches are commented by CI user
(with no email info) and following exception occurs:
raceback (most recent call last):
  File "/usr/bin/did", line 36, in <module>
    did.cli.main()
  File "/usr/lib/python2.7/site-packages/did/cli.py", line 183, in main
    user_stats.check()
  File "/usr/lib/python2.7/site-packages/did/stats.py", line 135, in check
    stat.check()
  File "/usr/lib/python2.7/site-packages/did/stats.py", line 135, in check
    stat.check()
  File "/usr/lib/python2.7/site-packages/did/stats.py", line 80, in check
    self.fetch()
  File "/usr/lib/python2.7/site-packages/did/plugins/gerrit.py", line 279, in fetch
    if owner == chg['author']['email'] and \
KeyError: 'email'