### PR TITLE
Improve readability of gerrit by using review number

### DIFF
--- a/did/plugins/gerrit.py
+++ b/did/plugins/gerrit.py
@@ -31,7 +31,7 @@ class Change(object):
         """ Initialize the change from the record.
         changelog['messages'] could be useful for collecting changes.
         """
-        self.id = ticket['id']
+        self.id = ticket['_number']
         self.change_id = ticket['change_id']
         self.subject = ticket['subject']
         self.ticket = ticket
@@ -40,7 +40,7 @@ class Change(object):
 
     def __unicode__(self):
         """ Consistent identifier and subject for displaying """
-        return u"{0}#{1} - {2}".format(self.prefix, self.id[:32], self.subject)
+        return u"{0}#{1} - {2}".format(self.prefix, self.id, self.subject)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
For example:

  * Changes abandoned: 1
    * GR#openstack-infra%2Fgrafyaml~maste - Change ignore-errors to...

now become:

  * Changes abandoned: 1
    * GR#225693 - Change ignore-errors to ignore_errors

Signed-off-by: Paul Belanger <pabelanger@redhat.com>