### PR TITLE
upgrade to argparse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ _build
 
 # rpm build files
 tmp/
+
+# vim autocomplete
+.cache

--- a/did/cli.py
+++ b/did/cli.py
@@ -9,10 +9,10 @@ running the main loop which gathers all individual stats.
 
 from __future__ import unicode_literals, absolute_import
 
+import argparse
 import re
 import sys
 import kerberos
-import optparse
 from dateutil.relativedelta import relativedelta as delta
 
 import did.base
@@ -31,8 +31,10 @@ class Options(object):
 
     def __init__(self, arguments=None):
         """ Prepare the parser. """
-        self.parser = optparse.OptionParser(
-            usage="did [last] [week|month|quarter|year] [opts]")
+        self.parser = argparse.ArgumentParser(
+            usage="did [last] [week|month|quarter|year] [opts]",
+            # --help now displays all default values
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         self.arguments = arguments
         self.opt = self.arg = None
 
@@ -41,17 +43,16 @@ class Options(object):
             utils.Logging("did").set(utils.LOG_DEBUG)
 
         # Time & user selection
-        group = optparse.OptionGroup(self.parser, "Select")
-        group.add_option(
+        group = self.parser.add_argument_group("Select")
+        group.add_argument(
             "--email", dest="emails", default=[], action="append",
             help="User email address(es)")
-        group.add_option(
+        group.add_argument(
             "--since",
             help="Start date in the YYYY-MM-DD format")
-        group.add_option(
+        group.add_argument(
             "--until",
             help="End date in the YYYY-MM-DD format")
-        self.parser.add_option_group(group)
 
         # Create sample stats and include all stats objects options
         log.debug("Loading Sample Stats group to build Options")
@@ -59,37 +60,35 @@ class Options(object):
         self.sample_stats.add_option(self.parser)
 
         # Formating options
-        group = optparse.OptionGroup(self.parser, "Format")
-        group.add_option(
+        group = self.parser.add_argument_group("Format")
+        group.add_argument(
             "--format", default="text",
             help="Output style, possible values: text (default) or wiki")
-        group.add_option(
-            "--width", default=did.base.Config().width, type="int",
-            help="Maximum width of the report output (default: %default)")
-        group.add_option(
+        group.add_argument(
+            "--width", default=did.base.Config().width, type=int,
+            help="Maximum width of the report output")
+        group.add_argument(
             "--brief", action="store_true",
             help="Show brief summary only, do not list individual items")
-        group.add_option(
+        group.add_argument(
             "--verbose", action="store_true",
             help="Include more details (like modified git directories)")
-        self.parser.add_option_group(group)
 
         # Other options
-        group = optparse.OptionGroup(self.parser, "Utils")
-        group.add_option(
+        group = self.parser.add_argument_group("Utils")
+        group.add_argument(
             "--config",
             metavar="FILE",
             help="Use alternate configuration file (default: 'config')")
-        group.add_option(
+        group.add_argument(
             "--total", action="store_true",
             help="Append total stats after listing individual users")
-        group.add_option(
+        group.add_argument(
             "--merge", action="store_true",
             help="Merge stats of all users into a single report")
-        group.add_option(
+        group.add_argument(
             "--debug", action="store_true",
             help="Turn on debugging output, do not catch exceptions")
-        self.parser.add_option_group(group)
 
     def parse(self, arguments=None):
         """ Parse the options. """
@@ -102,7 +101,8 @@ class Options(object):
         # Otherwise properly decode command line arguments
         if self.arguments is None:
             self.arguments = [arg.decode("utf-8") for arg in sys.argv[1:]]
-        (opt, arg) = self.parser.parse_args(self.arguments)
+        # http://stackoverflow.com/a/6835917/1289080
+        (opt, arg) = self.parser.parse_known_args(self.arguments)
         self.opt = opt
         self.arg = arg
         self.check()
@@ -205,19 +205,20 @@ def main(arguments=None):
         utils.info("Create at least a minimum config file {0}:\n{1}".format(
             did.base.Config.path(), did.base.Config().example().strip()))
         log.error(error)
-        sys.exit(1)
+        # return the actual error in HD, don't mask it in a sys exit
+        raise
 
     except (OptionError, ReportError) as error:
         log.error(error)
-        sys.exit(1)
+        raise
 
     except kerberos.GSSError as error:
         log.debug(error)
         log.error("Kerberos authentication failed. Try kinit.")
-        sys.exit(2)
+        raise
 
     except Exception as error:
         if "--debug" in sys.argv:
             raise
         log.error(error)
-        sys.exit(3)
+        raise

--- a/did/stats.py
+++ b/did/stats.py
@@ -4,7 +4,6 @@
 
 from __future__ import unicode_literals, absolute_import
 
-import optparse
 import xmlrpclib
 
 import did.base
@@ -54,7 +53,7 @@ class Stats(object):
 
     def add_option(self, group):
         """ Add option for self to the parser group object. """
-        group.add_option(
+        group.add_argument(
             "--{0}".format(self.option), action="store_true", help=self.name)
 
     def enabled(self):
@@ -122,12 +121,12 @@ class StatsGroup(Stats):
     def add_option(self, parser):
         """ Add option group and all children options. """
 
-        group = optparse.OptionGroup(parser, self.name)
+        group = parser.add_argument_group(self.name)
         for stat in self.stats:
             stat.add_option(group)
-        group.add_option(
+
+        group.add_argument(
             "--{0}".format(self.option), action="store_true", help="All above")
-        parser.add_option_group(group)
 
     def check(self):
         """ Check all children stats. """

--- a/tests/plugins/test_git.py
+++ b/tests/plugins/test_git.py
@@ -4,8 +4,10 @@
 from __future__ import unicode_literals, absolute_import
 
 import os
+
 import did.cli
 import did.utils
+from did.base import ReportError
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -63,7 +65,7 @@ def test_git_non_existent():
     did.base.Config(CONFIG.format("i-do-not-exist"))
     try:
         did.cli.main(INTERVAL)
-    except SystemExit:
+    except (SystemExit, ReportError):
         pass
     else:
         raise RuntimeError("Expected failure")

--- a/tests/plugins/test_github.py
+++ b/tests/plugins/test_github.py
@@ -4,6 +4,8 @@
 from __future__ import unicode_literals, absolute_import
 
 import pytest
+
+from did.base import ReportError
 import did.cli
 
 
@@ -45,11 +47,11 @@ def test_github_issues_closed():
 def test_github_invalid_token():
     """ Invalid token """
     did.base.Config(CONFIG + "\ntoken = bad-token")
-    with pytest.raises(SystemExit):
+    with pytest.raises((SystemExit, ReportError)):
         did.cli.main(INTERVAL)
 
 def test_github_missing_url():
     """ Missing url """
     did.base.Config("[gh]\ntype = github")
-    with pytest.raises(SystemExit):
+    with pytest.raises((SystemExit, ReportError)):
         did.cli.main(INTERVAL)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import os
 import re
 import did.cli
 import did.utils
+from did.base import OptionError
 
 # Prepare path and config examples
 PATH = os.path.dirname(os.path.realpath(__file__))
@@ -14,6 +15,7 @@ MINIMAL = did.base.Config.example()
 EXAMPLE = "".join(open(PATH + "/../examples/config").readlines())
 # Substitute example git paths for real life directories
 EXAMPLE = re.sub(r"\S+/git/[a-z]+", PATH, EXAMPLE)
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Minimal Config
@@ -26,6 +28,7 @@ def test_help_minimal():
         did.cli.main(["--help"])
     except SystemExit:
         pass
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Example Config
@@ -50,7 +53,7 @@ def test_invalid_arguments():
     for argument in ["a", "b", "c", "something"]:
         try:
             did.cli.main(argument)
-        except SystemExit:
+        except (SystemExit, OptionError):
             pass
         else:
             raise RuntimeError(


### PR DESCRIPTION
http://stackoverflow.com/questions/3217673/why-use-argparse-rather-than-optparse

    As of 2.7, optparse is deprecated, and will hopefully go away in the future.

Deprecated. I think it's clear optparse should be replaced with argparse. The migration is pretty simple. I think this covers everything. 

Sub commands are also a bit nicer in my experience.