### PR TITLE
don't create new Logging instance uncessarily

### DIFF
--- a/did/cli.py
+++ b/did/cli.py
@@ -38,7 +38,7 @@ class Options(object):
 
         # Enable debugging output (even before options are parsed)
         if "--debug" in sys.argv:
-            utils.Logging("did").set(utils.LOG_DEBUG)
+            log.setLevel(utils.LOG_DEBUG)
 
         # Time & user selection
         group = optparse.OptionGroup(self.parser, "Select")


### PR DESCRIPTION
Minor thing; why call utils.Logging("did") instead of just using the logger already cached into the namespace?

cli.py lines
    20 from did.utils import log
...
```
 39         # Enable debugging output (even before options are parsed)
 40         if "--debug" in sys.argv:
 41             utils.Logging("did").set(utils.LOG_DEBUG)
```

did.utils.log is utils.Logging("did").logger

What about

```
 39         # Enable debugging output (even before options are parsed)
 40         if "--debug" in sys.argv:
 41             log.setLevel(utils.LOG_DEBUG)
```