### PR TITLE
Enable use of requests[-kerberos] if installed

### DIFF
--- a/did/utils.py
+++ b/did/utils.py
@@ -39,6 +39,17 @@ EMAIL_REGEXP = re.compile(r'(?:"?([^"]*)"?\s)?(?:<?(.+@[^>]+)>?)')
 #  Utils
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+def as_bool(var):
+    """ Convert unparsed config variable to bool equivalent """
+    if isinstance(var, (str, unicode)):
+        var = var.lower()
+        if var in ['false', '0']:
+            var = False
+        else:
+            var = True
+    return bool(var)
+
+
 def eprint(text):
     """ Print (optionaly encoded) text """
     # When there's no terminal we need to explicitly encode strings.

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,13 @@ __xrequires__ = {
     'bootstrap': [
         'sphinx_bootstrap_theme',
     ],
+    'requests': [
+        'requests==2.7.0',
+        'requests-kerberos==0.7.0',
+    ],
+    #'bugzilla': [
+    #    'python-bugzilla==1.2.2',
+    #],
 }
 
 pip_src = 'https://pypi.python.org/packages/source'

--- a/tests/plugins/test_jira.py
+++ b/tests/plugins/test_jira.py
@@ -73,4 +73,4 @@ def assert_conf_error(config, expected_error=ReportError):
     except ReportError as e:
         error = e
     assert type(error) == expected_error
-    
+


### PR DESCRIPTION
Installation

```
pip install -e .[requests]
```

Enable use of requests[-kerberos] if installed
Fallback to using urllib2 if requests dependencies aren't available
Requests depedencies included as extras in setup.py
Enabled ssl_verify setting in config
New helper util added to convert untyped ConfigParser bool values
