### PR TITLE
Use UTC datetimes for Date()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,12 @@ format ``Name Surname <email@example.org>`` to display full name
 in the report output. For date values ``today`` and ``yesterday``
 can be used instead of the full date format.
 
+Note, all dates are assumed to be UTC unless otherwise specified. 
+ISO format dates can be used to specify otherwise. eg, 
+
+ * midnight CET is `2014-12-31 22:00:00 +0000` UTC (10pm)
+ * midnight UTC is `2015-01-01 02:00:00 +0200` CET (2am)
+
 --email=EMAILS
     User email address(es)
 

--- a/did/plugins/bitly.py
+++ b/did/plugins/bitly.py
@@ -29,7 +29,7 @@ from bitly_api import Connection
 
 from did.stats import Stats, StatsGroup
 from did.utils import log, pretty
-from did.base import Config, ReportError, ConfigError
+from did.base import Config, ConfigError
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  bit.ly
@@ -109,8 +109,8 @@ class SavedLinks(Stats):
         '''
         Bit.ly API expect unix timestamps
         '''
-        since = time.mktime(self.options.since.datetime.timetuple())
-        until = time.mktime(self.options.until.datetime.timetuple())
+        since = time.mktime(self.options.since.date.timetuple())
+        until = time.mktime(self.options.until.date.timetuple())
         log.info("Searching for links saved by {0}".format(self.user))
         self.stats = self.parent.bitly.user_link_history(created_after=since,
                                                          created_before=until)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ __irequires__ = [
     'urllib2_kerberos',
     'python-bugzilla',  # FIXME: make optional? see __xrequires__
     'pykerberos',
+    'pytz==2015.6',
 ]
 __xrequires__ = {
     # `install` usage: pip install did[tests,docs]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,10 +2,16 @@
 
 from __future__ import unicode_literals, absolute_import
 
+from datetime import date, datetime
 import pytest
-import datetime
+import pytz
+
 import did.base
 from did.base import Config, ConfigError
+
+UTC = pytz.utc
+CET = pytz.timezone('CET')
+
 
 def test_base_import():
     # simple test that import works
@@ -21,9 +27,11 @@ def test_Config():
     from did.base import Config
     assert Config
 
+
 def test_Config_email():
     config = Config("[general]\nemail = email@example.com\n")
     assert config.email == "email@example.com"
+
 
 def test_Config_email_missing():
     config = Config("[general]\n")
@@ -32,6 +40,7 @@ def test_Config_email_missing():
     config = Config("[missing]")
     with pytest.raises(did.base.ConfigError):
         config.email == "email@example.com"
+
 
 def test_Config_width():
     config = Config("[general]\n")
@@ -44,14 +53,78 @@ def test_Config_width():
 #  Date
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-def test_Date():
+def test_TODAY():
+    from did.base import TODAY
+
+    d = TODAY.date()
+    _d = datetime.utcnow().replace(tzinfo=pytz.utc).date()
+    assert d == _d
+
+
+def test_import_Date():
     from did.base import Date
     assert Date
 
 
+def test_Date_type_handling():
+    from did.base import Date
+
+    # clearly not dates
+    BAD_DATES = [int(1), 'BAD DATE']
+    for bad in BAD_DATES:
+        with pytest.raises(did.base.OptionError):
+            Date(bad)
+
+    # Date, no timezone or time even
+    D_today = date(2015, 1, 1)
+    d_today = '2015-01-01'
+    assert unicode(Date(d_today)) == d_today
+    # should always have utc timezone attached
+    assert Date(d_today).date.tzinfo == pytz.utc
+    # try with datetime instance
+    assert unicode(Date(D_today)) == d_today
+
+    # UTC
+    DT_today_utc = datetime(2015, 1, 1, 0, 0, 0, tzinfo=UTC)
+    dt_today_utc = '2015-01-01 00:00:00.000 +0000'
+    assert unicode(Date(dt_today_utc)) == d_today
+    # should always have utc timezone attached
+    # so this is the last time we test for it since it's been found 2x already
+    assert Date(dt_today_utc).date.tzinfo == pytz.utc
+
+    # UTC using 'T' instead of ' ' (space) between date and time
+    dt_today_utc = '2015-01-01T00:00:00.000 +0000'
+    #                         ^
+    assert unicode(Date(dt_today_utc)) == d_today
+    DT_today_utc = datetime(2015, 1, 1, 0, 0, 0, tzinfo=UTC)
+    # Try with datetime
+    assert unicode(Date(DT_today_utc)) == d_today
+
+    # CET
+    DT_today_cet = datetime(2015, 1, 1, 0, 0, 0, tzinfo=CET)
+    dt_today_cet = '2015-01-01 00:00:00.000 +0200'
+    d_today_UTC_from_CET = '2014-12-31'
+    assert unicode(Date(dt_today_cet)) == d_today_UTC_from_CET
+    assert unicode(Date(DT_today_cet)) == d_today_UTC_from_CET
+
+    # UNSPECIFIED timezone (assumed UTC)
+    DT_today_x = datetime(2015, 1, 1, 0, 0, 0)
+    dt_today_x = '2015-01-01 00:00:00'
+    assert unicode(Date(dt_today_x)) == d_today
+    assert unicode(Date(DT_today_x)) == d_today
+
+    # CET specific time, 12:00:00
+    dt_today_noon_cet = '2015-01-01 12:00:00 +0200'
+    iso = '%Y-%m-%d %H:%M:%S %z'
+
+    _DT = unicode(Date(dt_today_noon_cet, fmt=iso))
+    dt_today_noon_cet_as_utc = '2015-01-01 10:00:00 +0000'
+    assert _DT == dt_today_noon_cet_as_utc
+
+
 def test_Date_period():
     from did.base import Date
-    did.base.TODAY = datetime.date(2015, 10, 3)
+    did.base.TODAY = date(2015, 10, 3)
     # This week
     for argument in ["", "week", "this week"]:
         since, until, period = Date.period(argument)
@@ -102,6 +175,44 @@ def test_Date_period():
         assert period == "the last fiscal year"
 
 
+def test_Date_format():
+    from did.base import Date
+
+    d = '2015-01-01'
+    dt = '2015-01-01 00:00:00'
+    dtz = '2015-01-01 00:00:00 +0000'
+    dtz_cet = '2015-01-01 00:00:00 +0200'
+    # since we're 2 hours ahead, in UTC we're 2 behind
+    dtz_cet_utc = '2014-12-31 22:00:00 +0000'
+    d_cet_utc = '2014-12-31'
+
+    # Default format will return the date in YYYY-MM-DD form
+    # after date conversion from defined timezone to UTC, if
+    # timezone is set on the incoming date value.
+    assert str(Date(d)) == d
+    assert str(Date(dt)) == str(d)
+    assert str(Date(dtz)) == str(d)
+    assert str(Date(dtz_cet)) == str(d_cet_utc)
+
+    # different formats should all work as strftime() expects
+    fmt = '%Y'
+    assert str(Date(d, fmt=fmt)) == '2015'
+    fmt = '%Y-%m-%d'
+    assert str(Date(d, fmt=fmt)) == d
+    fmt = '%Y-%m-%d %H:%M:%S'
+    assert str(Date(dt, fmt=fmt)) == dt
+    fmt = '%Y-%m-%d %H:%M:%S %z'
+    assert str(Date(dt, fmt=fmt)) == dtz
+    assert str(Date(d, fmt=fmt)) == dtz
+
+    # unicode works as expected
+    assert unicode(Date('2015-01-01')) == unicode(d)
+
+    # specify timezone
+    iso = '%Y-%m-%d %H:%M:%S %z'
+    assert unicode(Date(dtz_cet, fmt=iso)) == dtz_cet_utc
+
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  User
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -130,7 +241,7 @@ def test_User():
     user = User("some@email.org")
     assert user.email == "some@email.org"
     assert user.login == "some"
-    assert user.name == None
+    assert user.name is None
     assert unicode(user) == "some@email.org"
 
     # Full email format
@@ -172,7 +283,6 @@ def test_User():
     user = User("some@email.org; bz: bzlogin")
     clone = user.clone("bz")
     assert clone.login == "bzlogin"
-
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Changed the default behaivor of Date() to
normalize everything to UTC timezone datetime.datetime
instances instead of datetime.date to maintain the
datetime resolution for cases where it matters.

Also, while the default unicode(Date()) outout is
YYYY-MM-DD, the format can now be changed on demand
using the fmt variable. eg (from tests/test_base.py)

```
from did.base import Date

d = '2015-01-01'
dt = '2015-01-01 00:00:00'
dtz = '2015-01-01 00:00:00 +0000'
dtz_cet = '2015-01-01 00:00:00 +0200'
# since we're 2 hours ahead, in UTC we're -2
dtz_cet_utc = '2014-12-31 22:00:00 +0000'
d_cet_utc = '2014-12-31'

# Default format will return the date in YYYY-MM-DD form
# after date conversion from defined timezone to UTC, if
# timezone is set on the incoming date value.
assert str(Date(d)) == d
assert str(Date(dt)) == str(d)
assert str(Date(dtz)) == str(d)
assert str(Date(dtz_cet)) == str(d_cet_utc)

# different formats should all work as strftime() expects
fmt = '%Y'
assert str(Date(d, fmt=fmt)) == '2015'
fmt = '%Y-%m-%d'
assert str(Date(d, fmt=fmt)) == d
fmt = '%Y-%m-%d %H:%M:%S'
assert str(Date(dt, fmt=fmt)) == dt
fmt = '%Y-%m-%d %H:%M:%S %z'
assert str(Date(dt, fmt=fmt)) == dtz
assert str(Date(d, fmt=fmt)) == dtz

# unicode works as expected
assert unicode(Date('2015-01-01')) == unicode(d)

# specify timezone
iso = '%Y-%m-%d %H:%M:%S %z'
assert unicode(Date(dtz_cet, fmt=iso)) == dtz_cet_utc
```

Requires one new dependency - pytz http://pythonhosted.org/pytz/

Fixed some misc tests that depended on old Date features which
needed to be migrated.
