### PR TITLE
FEATURE: Logg - easily track what you did each day

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,0 +1,3 @@
+pylint:
+  disable:
+    - logging-format-interpolation

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,12 @@ python:
 #  - "3.3"
 #  - "3.4"
 before_install:
+  - "git --version"
   - "pip install -U pip setuptools virtualenv coveralls"
+  - "git config --global user.email 'cward@redhat.com'"
+  - "git config --global user.name 'Chris Ward'"
 install:
-  - "pip install -e .[bitly]"
+  - "pip install -e .[bitly,logg]"
   - "git fetch --unshallow"
 script:
   - "coverage run --source=bin,did -m py.test $CAPTURE tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - "git config --global user.email 'cward@redhat.com'"
   - "git config --global user.name 'Chris Ward'"
 install:
-  - "pip install -e .[bitly,logg]"
+  - "pip install -e .[bitly,kerberos,logg]"
   - "git fetch --unshallow"
 script:
   - "coverage run --source=bin,did -m py.test $CAPTURE tests"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ tmp:
 
 # Run the test suite, optionally with coverage
 test: tmp
-	DID_DIR=$(TMP) py.test tests
+	DID_DIR=$(TMP) py.test tests -s
 smoke: tmp
 	DID_DIR=$(TMP) py.test tests/test_cli.py
 coverage: tmp

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,12 @@ format ``Name Surname <email@example.org>`` to display full name
 in the report output. For date values ``today`` and ``yesterday``
 can be used instead of the full date format.
 
+Note, all dates are assumed to be UTC unless otherwise specified. 
+ISO format dates can be used to specify otherwise. eg, 
+
+ * midnight CET is `2014-12-31 22:00:00 +0000` UTC (10pm)
+ * midnight UTC is `2015-01-01 02:00:00 +0200` CET (2am)
+
 --email=EMAILS
     User email address(es)
 

--- a/README.rst
+++ b/README.rst
@@ -3,24 +3,31 @@
     did
 ======================
 
-What did you do last week, month, year?
+What did you do today, yesterday, last week, month, year?
 
 
 Description
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Comfortably gather status report data (e.g. list of committed
-changes) for given week, month, quarter, year or selected date
-range. By default all available stats for this week are reported.
+Comfortably gather and save status report data (e.g. list of 
+committed changes) for given day, week, month, quarter, year or 
+selected date range. 
+
+By default, ``did`` report returns all available stats for the 
+current week. ``idid`` saves the activity as completed today.
 
 
 Synopsis
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Usage is straightforward::
+Usage for loading stats from configured sources is 
+straightforward::
 
     did [this|last] [week|month|quarter|year] [opts]
 
+Usage for saving loggs to configured sources is too::
+
+    idid [today|yesterday|YYYY-MM-DD] [topic] 'logg msg' [opts] 
 
 Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -37,7 +44,17 @@ Gather stats for the last month::
 
     did last month
 
+Save a Logg, then display it::
+
+    idid joy '@psss merged all my #github pull requests!'
+    did this week --logg
+
 See ``did --help`` for complete list of available stats.
+
+Save a did logg to the default target topic branch 'unsorted'::
+
+    idid 'changed the flat tire on my car'
+    did today
 
 
 Options
@@ -148,10 +165,16 @@ settings and configuration of individual reports::
     email = "Petr Šplíchal" <psplicha@redhat.com>
     width = 79
 
+    [logg]
+    engine = txt
+
+    [joy]
+    type = logg
+    desc = Joy of the week
+
     [header]
     type = header
     highlights = Highlights
-    joy = Joy of the week ;-)
 
     [tools]
     type = git

--- a/README.rst
+++ b/README.rst
@@ -36,9 +36,10 @@ Gather all stats for current week::
 
     did
 
-Show me all stats for today::
+Show me all stats for today/yesterday::
 
     did today
+    did yesterday
 
 Gather stats for the last month::
 
@@ -232,7 +233,7 @@ Authors
 
 Petr Šplíchal, Karel Šrot, Lukáš Zachar, Matěj Cepl, Ondřej Pták,
 Chris Ward, Tomáš Hofman, Martin Mágr, Stanislav Kozina, Paul
-Belanger and Eduard Trott.
+Belanger, Eduard Trott, Martin Frodl and Randy Barlow.
 
 
 Copyright

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Synopsis
 
 Usage is straightforward::
 
-    did [last] [week|month|quarter|year] [opts]
+    did [this|last] [week|month|quarter|year] [opts]
 
 
 Examples

--- a/bin/idid
+++ b/bin/idid
@@ -3,8 +3,8 @@
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-#   did - What did you do today, yesterday, last week, month, year?
-#   Author: Petr Šplíchal <psplicha@redhat.com>
+#   idid - Logg what did you did today, yesterday, last week or year?
+#   Author: Chris Ward <cward@redhat.com>
 #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
@@ -31,7 +31,8 @@ Comfortably gather and store status report data (e.g. list of
 committed changes) for given week, month, quarter, year or selected
 date range.
 
-By default ``did`` reports all configured stats for this week.
+By default ``idid`` stores your logg activity snippets as if they
+were completed today.
 
 
 """
@@ -43,8 +44,8 @@ import did.base
 import did.utils
 
 try:
-    did.cli.main()
-except did.base.GeneralError as error:
+    did.cli.main(is_logg=True)
+except Exception as error:
     if "--debug" in sys.argv:
         raise
     did.utils.log.error(error)

--- a/did.spec
+++ b/did.spec
@@ -1,5 +1,5 @@
 Name: did
-Version: 0.8
+Version: 0.9
 Release: 1%{?dist}
 
 Summary: What did you do last week, month, year?
@@ -43,6 +43,24 @@ install -pm 644 did.1.gz %{buildroot}%{_mandir}/man1
 %license LICENSE
 
 %changelog
+* Mon Apr 04 2016 Petr Šplíchal <psplicha@redhat.com> 0.9-1
+- New plugins supported: Trello, bit.ly, idonethis
+- Support 'did yesterday' for yesterday's updates
+- Ignore comment updates without author specified
+- User does not have to be assignee to close a bug
+- Create vim tags using the 'make tags' target
+- Use option prefix also for git, header and footer
+- Extend the test coverage for cli, base and utils
+- Rename DID_CONFIG to DID_DIR to match the content
+- Improve error handling, especially config errors
+- Migrate option parsing from optparse to argparse
+- Configurable support for showing bug resolutions
+- Support --conf as abbreviation for --config
+- Initial set of tests for the trac plugin
+- Improve readability of gerrit by using review number
+- Improve closed bugs stats, add test case [fix #45]
+- Add statistics of closed bugs for bugzilla plugin
+
 * Wed Sep 23 2015 Petr Šplíchal <psplicha@redhat.com> 0.8-1
 - Give warning for git repository problems [fix #41]
 - Add example with config dir set to: ~/.config/did/

--- a/did/base.py
+++ b/did/base.py
@@ -353,6 +353,11 @@ class Date(object):
             until = Date("today")
             until.date += delta(days=1)
             period = "today"
+        elif "yesterday" in argument:
+            since = Date("yesterday")
+            until = Date("yesterday")
+            until.date += delta(days=1)
+            period = "yesterday"
         elif "year" in argument:
             if "last" in argument:
                 since, until = Date.last_year()

--- a/did/base.py
+++ b/did/base.py
@@ -14,17 +14,20 @@ import ConfigParser
 from dateutil.relativedelta import MO as MONDAY
 from ConfigParser import NoOptionError, NoSectionError
 from dateutil.relativedelta import relativedelta as delta
+from dateutil.parser import parse as dt_parse
+import pytz
 
 from did import utils
 from did.utils import log
-
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Constants
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Config file location
-CONFIG = os.path.expanduser("~/.did")
+DID_DIR = os.path.expanduser("~/.did")
+DID_CONFIG_FILENAME = 'config'
+DID_CONFIG_PATH = os.path.join(DID_DIR, DID_CONFIG_FILENAME)
 
 # Default maximum width
 MAX_WIDTH = 79
@@ -77,29 +80,31 @@ class Config(object):
         If no config or path given, default to "~/.did/config" which
         can be overrided by the ``DID_DIR`` environment variable.
         """
-        # Read the config only once (unless explicitly provided)
-        if self.parser is not None and config is None and path is None:
-            return
-        Config.parser = ConfigParser.SafeConfigParser()
-        # If config provided as string, parse it directly
-        if config is not None:
-            log.info("Inspecting config file from string")
+        self.parser = ConfigParser.SafeConfigParser()
+        path = os.path.expanduser(path or Config.path())
+        # if we have an existing config instance, make a new copy
+        config = unicode(config) if isinstance(config, Config) else config
+        if config:
+            # If config provided as string, parse it directly
+            log.debug("Inspecting config file string")
             log.debug(utils.pretty(config))
             self.parser.readfp(StringIO.StringIO(config))
-            return
-        # Check the environment for config file override
-        # (unless path is explicitly provided)
-        if path is None:
-            path = Config.path()
-        # Parse the config from file
-        try:
-            log.info("Inspecting config file '{0}'.".format(path))
-            self.parser.readfp(codecs.open(path, "r", "utf8"))
-        except IOError as error:
-            log.debug(error)
-            Config.parser = None
-            raise ConfigFileError(
-                "Unable to read the config file '{0}'.".format(path))
+        elif os.path.exists(path):
+            # Otherwise, parse the config from file
+            try:
+                log.info("Inspecting config file '{0}'.".format(path))
+                config_file = codecs.open(path, "r", "utf8")
+                self.parser.readfp(config_file)
+            except IOError as error:
+                # FIXME: why not just raise IOError and catch it?
+                log.error(error)
+                raise ConfigFileError(
+                    "Unable to read the config file '{0}'.".format(path))
+        elif path and not os.path.exists(path):
+            log.warn('Invalid path to config file: {0}'.format(path))
+        else:
+            assert not path and not config
+            log.warn('No config string or path to config file provided')
 
     @property
     def email(self):
@@ -142,8 +147,26 @@ class Config(object):
         """ Return section items, skip selected (type/order by default) """
         if skip is None:
             skip = ['type', 'order']
-        return [(key, val) for key, val in self.parser.items(section)
-                if key not in skip]
+
+        # ConfigParser doesn't convert 'true' or 'false' to True/False...?
+        def _type(x):
+            if x == 'true':
+                x = True
+            elif x == 'false':
+                x = False
+            else:
+                pass
+            return x
+
+        try:
+            _section = self.parser.items(section)
+        except Exception as err:
+            log.debug(err)
+            raise ConfigFileError('Invalid section: {0}'.format(section))
+        else:
+            _args = [(key, _type(val)) for key, val in _section
+                     if key not in skip]
+        return _args
 
     def item(self, section, it):
         """ Return content of given item in selected section """
@@ -157,21 +180,44 @@ class Config(object):
     def path():
         """ Detect config file path """
         # Detect config directory
-        try:
-            directory = os.environ["DID_DIR"]
-        except KeyError:
-            directory = CONFIG
+        directory = os.environ.get("DID_DIR") or DID_DIR
         # Detect config file (even before options are parsed)
-        filename = "config"
         matched = re.search("--confi?g?[ =](\S+)", " ".join(sys.argv))
-        if matched:
-            filename = matched.groups()[0]
-        return directory.rstrip("/") + "/" + filename
+        filename = matched.groups()[0] if matched else DID_CONFIG_FILENAME
+        return os.path.join(directory, filename)
 
     @staticmethod
     def example():
         """ Return config example """
         return "[general]\nemail = Name Surname <email@example.org>\n"
+
+    def __unicode__(self):
+        output = StringIO.StringIO()
+        self.parser.write(output)
+        return output.getvalue()
+
+    def __str__(self):
+        return self.__unicode__()
+
+
+def get_config(config=None, path=None):
+    if config:
+        log.debug('Getting Config from string: {0}'.format(config))
+        config = Config(config=config)
+    elif path:
+        log.debug('Getting Config from file path: {0}'.format(path))
+        config = Config(path=path)
+    else:
+        # log.debug('Getting default config')  # this is too loud...
+        config = DID_CONFIG
+    return config
+
+
+def set_config(config=None, path=None):
+    global DID_CONFIG
+    log.debug('Setting Config...')
+    DID_CONFIG = get_config(config, path)
+    return DID_CONFIG
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -182,24 +228,6 @@ class Date(object):
     """ Date parsing for common word and string formats """
 
     fmt = None
-
-    def __init__(self, date=None):
-        """ Parse the date string """
-        if isinstance(date, datetime.date):
-            self.date = date
-        elif date is None or date.lower() == "today":
-            self.date = TODAY
-        elif date.lower() == "yesterday":
-            self.date = TODAY - delta(days=1)
-        else:
-            try:
-                self.date = datetime.date(*[int(i) for i in date.split("-")])
-            except StandardError as error:
-                log.debug(error)
-                raise OptionError(
-                    "Invalid date format: '{0}', use YYYY-MM-DD.".format(date))
-        self.datetime = datetime.datetime(
-            self.date.year, self.date.month, self.date.day, 0, 0, 0)
 
     def __init__(self, date=None, fmt=None):
         """ Parse the date string """
@@ -390,8 +418,11 @@ class User(object):
         login = psss
     """
 
+    config = None
+
     def __init__(self, email, stats=None):
         """ Detect name, login and email """
+        self.config = DID_CONFIG
         # Make sure we received the email string, save the original for cloning
         if not email:
             raise ConfigError("Email required for user initialization.")
@@ -429,16 +460,16 @@ class User(object):
             return
         # Attempt to use alias directly from the config section
         try:
-            config = dict(Config().section(stats))
+            _config = dict(self.config.section(stats))
             try:
-                email = config["email"]
+                email = _config["email"]
             except KeyError:
                 pass
             try:
-                login = config["login"]
+                login = _config["login"]
             except KeyError:
                 pass
-        except (ConfigFileError, NoSectionError):
+        except (ConfigFileError, NoSectionError, AttributeError):
             pass
         # Check for aliases specified in the email string
         if aliases is not None:
@@ -463,3 +494,13 @@ class User(object):
         if login is not None:
             self.login = login
             log.info("Using login alias '{0}' for '{1}'".format(login, stats))
+
+
+# By default this loads config from ~/.did/config
+# unless dir path in os.environ['DID_DIR'] is set, which .path() picks up
+# or argv contains --config=/did/path/
+try:
+    DID_CONFIG = Config(path=Config.path())
+except Exception as err:
+    log.error('Failed to load default config file! {0}'.format(err))
+    DID_CONFIG = None

--- a/did/cli.py
+++ b/did/cli.py
@@ -5,6 +5,23 @@ Command line interface for did
 
 This module takes care of processing command line options and
 running the main loop which gathers all individual stats.
+
+Usage, for saving did logg's::
+
+    idid chores 'Cleaned my inbox #ftw'
+    idid proj_x 'Drafted Project X Charter'
+    idid yesterday proj_x 'Fixed the leaky pipe'
+    idid 2015-05-05T09:00:00 confs 'Attended PyCon CZ in Brno'
+    idid 'something amazing today! #lifeisgreat'
+
+If a target Logg topic branch is not specificed, 'unsorted' will be used.
+
+Usage, for reporting did logg's::
+
+    did
+    did today
+    did last week --logg
+
 """
 
 from __future__ import unicode_literals, absolute_import
@@ -19,48 +36,96 @@ import did.base
 import did.utils as utils
 from did.utils import log
 from did.stats import UserStats
+from did.logg import Logg, DT_ISO_FMT
 
+VALID_LONG_DT_KEYWORDS = "this last".split()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Options
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+DID_USAGE = "did [today|DATE|...] [[this|last] [week|month|...]] [options]"
+IDID_USAGE = "idid [today|DATE|...] [topic] 'Logg record' [options]"
+
+
 class Options(object):
     """ Command line options parser """
 
+    arguments = None
+    config = None
+
     def __init__(self, arguments=None):
-        """ Prepare the parser. """
-        self.parser = argparse.ArgumentParser(
-            usage="did [this|last] [week|month|quarter|year] [options]")
-        self.arguments = arguments
-        self.opt = self.arg = None
+        """ Prepare the shared [i]did argument parser """
+        self.parser = argparse.ArgumentParser(usage=DID_USAGE)
+        # if we don't pass args, we can assume we're calling this via CLI
+        # so grab the args from sys.argv instead
+        self.arguments = arguments or sys.argv[1:]
+        log.debug(' ... arguments? {0}'.format(self.arguments))
 
         # Enable debugging output (even before options are parsed)
-        if "--debug" in sys.argv:
+        if "--debug" in self.arguments:
             log.setLevel(utils.LOG_DEBUG)
+        #  Turn off everything except errors, including warnings
+        if "--quiet" in self.arguments:
+            log.setLevel(utils.LOG_ERROR)
 
-        # Get the default output width from the config (if available)
-        try:
-            width = did.base.Config().width
-        except did.base.ConfigFileError:
-            width = did.base.MAX_WIDTH
+        # Head / Parent parser (shared)
+        # Add Debug option
+        self.parser.add_argument(
+            "--debug", action="store_true",
+            help="Turn on debugging output, do not catch exceptions")
+        # Add quiet, which overrides debug if both are issued
+        self.parser.add_argument(
+            "--quiet", action="store_true",
+            help="Turn off all logging except errors; catch exceptions")
 
         # Time & user selection
         group = self.parser.add_argument_group("Select")
         group.add_argument(
             "--email", dest="emails", default=[], action="append",
             help="User email address(es)")
-        group.add_argument(
-            "--since",
-            help="Start date in the YYYY-MM-DD format")
-        group.add_argument(
-            "--until",
-            help="End date in the YYYY-MM-DD format")
+        group.add_argument("--since", help="Start date in YYYY-MM-DD format")
+        group.add_argument("--until", help="End date in YYYY-MM-DD format")
 
-        # Create sample stats and include all stats objects options
-        log.debug("Loading Sample Stats group to build Options")
-        self.sample_stats = UserStats()
-        self.sample_stats.add_option(self.parser)
+    def parse(self, arguments=None):
+        """ Parse the shared [i]did arguments """
+        arguments = self.arguments or arguments
+        # FIXME: prep/normalize arguments in __init__
+        # Split arguments if given as string and run the parser
+        if isinstance(arguments, basestring):
+            arguments = utils.split(arguments)
+
+        # run the wrapped argparser command to gather user set arg values
+        # FROM: https://docs.python.org/3/library/argparse.html
+        # Sometimes a script may only parse a few of the command-line
+        # arguments, passing the remaining arguments on to another script or
+        # program.  In these cases, the parse_known_args() method can be
+        # useful. It works much like parse_args() except that it does not
+        # produce an error when extra arguments are present. Instead, it
+        # returns a two item tuple containing the populated namespace and
+        # the list of remaining argument strings.
+        opts, _arguments = self.parser.parse_known_args(arguments)
+
+        # if we're passing arguments in as a string we might get \n's or null
+        # strings '' that we want to be sure to ignore
+        _arguments = filter(
+            lambda x: x if x else None, [_.strip() for _ in _arguments if _])
+
+        # Now let the subclass parse the remaining special opts that
+        # weren't consumed by default argparser
+        opts = self._parse(opts, _arguments)
+        return opts
+
+
+class ReportOptions(Options):
+    """ ``did`` command line arguments parser """
+
+    def __init__(self, arguments=None):
+        """ Customize argument parser for ``did``"""
+        super(ReportOptions, self).__init__(arguments=arguments)
+
+        self.parser.add_argument(
+            "--all", action="store_true", help="Get all available stats")
 
         # Formating options
         group = self.parser.add_argument_group("Format")
@@ -68,7 +133,7 @@ class Options(object):
             "--format", default="text",
             help="Output style, possible values: text (default) or wiki")
         group.add_argument(
-            "--width", default=width, type=int,
+            "--width", default=did.base.MAX_WIDTH, type=int,
             help="Maximum width of the report output (default: %(default)s)")
         group.add_argument(
             "--brief", action="store_true",
@@ -89,122 +154,268 @@ class Options(object):
         group.add_argument(
             "--merge", action="store_true",
             help="Merge stats of all users into a single report")
-        group.add_argument(
-            "--debug", action="store_true",
-            help="Turn on debugging output, do not catch exceptions")
 
-    def parse(self, arguments=None):
-        """ Parse the options. """
-        # Split arguments if given as string and run the parser
-        if arguments is not None:
-            self.arguments = arguments
-        if (self.arguments is not None
-                and isinstance(self.arguments, basestring)):
-            self.arguments = self.arguments.split()
-        # Otherwise properly decode command line arguments
-        if self.arguments is None:
-            self.arguments = [arg.decode("utf-8") for arg in sys.argv[1:]]
-        opt, arg = self.parser.parse_known_args(self.arguments)
-        self.opt = opt
-        self.arg = arg
-        self.check()
+    def parse(self, *args, **kwargs):
+        """ Load plugin arguments before parsing CLI arguments """
+        # Create sample stats and include all stats objects options
 
-        # Enable --all if no particular stat or group selected
-        opt.all = not any([
-            getattr(opt, stat.dest) or getattr(opt, group.dest)
+        # NOTE: Only those plugins which have a value configured in the user's
+        # config file will be loaded.
+
+        log.debug("Loading Sample Stats group to build Options")
+        self.sample_stats = UserStats()
+        self.sample_stats.add_option(self.parser)
+        return super(ReportOptions, self).parse(*args, **kwargs)
+
+    def _parse(self, opts, args):
+        """ Perform additional check for ``did`` command arguments """
+        # did [today|yesterday|this...] [week|month|...]
+        assert isinstance(args, list)
+
+        # return all stats if one or more are specified explicitly
+        opts.all = not any([
+            getattr(opts, stat.dest) or getattr(opts, group.dest)
             for group in self.sample_stats.stats
             for stat in group.stats])
 
         # Time period handling
-        if opt.since is None and opt.until is None:
-            opt.since, opt.until, period = did.base.Date.period(arg)
+        if opts.since is None and opts.until is None:
+            opts.since, opts.until, opts.period = did.base.Date.period(args)
         else:
-            opt.since = did.base.Date(opt.since or "1993-01-01")
-            opt.until = did.base.Date(opt.until or "today")
+            opts.since = did.base.Date(opts.since or "1993-01-01")
+            opts.until = did.base.Date(opts.until or "today")
             # Make the 'until' limit inclusive
-            opt.until.date += delta(days=1)
-            period = "given date range"
+            opts.until.date += delta(days=1)
+            opts.period = "given date range"
 
         # Validate the date range
-        if not opt.since.date < opt.until.date:
+        if not opts.since.date < opts.until.date:
             raise RuntimeError(
                 "Invalid date range ({0} to {1})".format(
-                    opt.since, opt.until.date - delta(days=1)))
-        header = "Status report for {0} ({1} to {2}).".format(
-            period, opt.since, opt.until.date - delta(days=1))
+                    opts.since, opts.until.date - delta(days=1)))
+
+        # This check needs to be run after ALL plugins have been loaded
+        # and their custom args have been added to the parser
+        # parser.parse_known_args() has been run; otherwise parse_known_args
+        # doesn't remove the plugin args from the arguments list since it
+        # doesn't know anything about them at the time it runs and thinks
+        # they aren't actually real argparser args, since in reality
+        # they aren't, since they haven't been added at the time this
+        # _parse() check is run currently.
+        keywords = "today yesterday this last week month quarter year".split()
+        err = [1 if arg not in keywords else 0 for arg in args]
+        if any(err):
+            raise did.base.OptionError(
+                "Invalid argument: '{0}'".format(args[err.index(1)]))
 
         # Finito
         log.debug("Gathered options:")
-        log.debug('options = {0}'.format(opt))
-        return opt, header
+        log.debug('options = {0}'.format(opts))
+        return opts
 
-    def check(self):
-        """ Perform additional check for given options """
-        keywords = "today this last week month quarter year".split()
-        for argument in self.arg:
-            if argument not in keywords:
-                raise did.base.OptionError(
-                    "Invalid argument: '{0}'".format(argument))
+
+class LoggOptions(Options):
+    """ ``idid`` command line arguments parser """
+
+    logg = None
+
+    def __init__(self, arguments=None):
+        """ Customize argument parser for ``idid``"""
+        super(LoggOptions, self).__init__(arguments=arguments)
+        self.parser.usage = IDID_USAGE
+
+    def _parse_date(self, dt, fmt=None):
+        """ Try to convert a given value to a did.base.Date() instance """
+        try:
+            # test if it's not a datelike instance ...
+            _dt = did.base.Date(dt, fmt=fmt)
+        except did.base.OptionError:
+            # nope, not a datelike instance
+            _dt = None
+        return _dt
+
+    def _parse(self, opts, args):
+        """ Perform additional check for ``idid`` command arguments """
+        k_args = len(args)
+        _dt = opts.date = None
+        logg = opts.logg = None
+        target = opts.target = None
+
+        log.debug(' ... got [{0}] args'.format(k_args))
+        if k_args == 0:
+            # launch the editor to save a message into 'unsorted' branch
+            # FIXME: 'unsorted' should be configurable as 'default branch'
+            log.warn('Target branch is not defined, using "unsorted"')
+            target, logg = 'unsorted', '--'
+
+        elif k_args == 1:
+            # NOTE: two different usage patterns can be expected here
+            # 1) did target   # launch EDITOR for logg in target topic
+            # 2) did 'logg record'  # save under default branch 'unsorted'
+            # if we have a value that's got more than one word in it, we
+            # assume it's a logg (B), otherwise (A)
+            arg = args.pop()
+            k_words = len(arg.split())
+            # variant A); user wants to launch the editor
+            # variany B); user wants to save record to 'unsorted' branch
+            # default to an unspecified, unsorted target branch since
+            # target not specified
+            target, logg = (arg, '--') if k_words == 1 else ('unsorted', arg)
+            if target == 'unsorted':
+                log.warn('Target branch is not defined, using "unsorted"')
+
+        elif k_args == 2:
+            # variants:
+            # 1) did [datetime] 'message'
+            # 2) did [datetime] target  # launch editor
+            # 3) did target logg
+            # 4) did unquoted logg  # NOT VALID
+            # 5) did last week  # NOT VALID
+            _one = args[0]
+            _two = args[1]
+
+            if _one in VALID_LONG_DT_KEYWORDS:
+                # scenario 5), pass the entire string to date
+                raise RuntimeError(
+                    "Invalid date use. Got: [{0} {1}]".format(_one, _two))
+
+            # try to parse a date from the value
+            _dt = self._parse_date(_one, DT_ISO_FMT)
+
+            # scenario 1) or 2), ambiguouos ... could be target or logg msg
+            # assume 2) by default, so... 1) is invalid
+            # scenario 3) or 4), ambiguous ... could be target or
+            # logg msg assume 3) by default, so... 4) is invalid
+            target, logg = (_two, '--') if _dt else (_one, _two)
+
+        elif k_args >= 3:
+            # variants:
+            # 1) did [datetime] target 'message'
+            # 2) did [datetime] unquoted logg  # NOT VALID
+            # 3) did target unquoted logg
+            _one = args[0]
+            _two = args[1]
+            _three = ' '.join(args[2:])
+
+            if _one in VALID_LONG_DT_KEYWORDS:
+                # scenario 5), pass the entire string to date
+                raise RuntimeError(
+                    "Invalid date use. Got: [{0} {1}]".format(_one, _two))
+
+            # try to parse a date from the value
+            _dt = self._parse_date(_one, DT_ISO_FMT)
+
+            # scenario 1) or 2), ambiguouos ... could be target or logg msg
+            # assume 1) by default, so... 2) is invalid
+            __combo = _two + ' ' + _three
+            target, logg = (_two, _three) if _dt else (_one, __combo)
+
+        opts.date = _dt or did.base.Date('today', fmt=DT_ISO_FMT)
+        opts.target = target
+        opts.logg = logg
+        log.debug(' Found Date: {0}'.format(_dt))
+        log.debug(' Found Target: {0}'.format(target))
+        log.debug(' Found Logg: {0}'.format(logg))
+        return opts
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Main
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-def main(arguments=None):
-    """
-    Parse options, gather stats and show the results
+def _run_logg(arguments, config):
+    # running idid logg
+    options = LoggOptions(arguments=arguments).parse()
+    logg = Logg(config)
+    r = logg.logg_record(options.target, options.logg, options.date)
+    # We're not doing everything else did does... Finito
+    return r
 
-    Takes optional parameter ``arguments`` which can be either
-    command line string or list of options. This is very useful
-    for testing purposes. Function returns a tuple of the form::
+
+def _run_report(arguments, config):
+    # We have a did report command
+    gathered_stats = []
+
+    # parse the cli arguments and gather options
+    options = ReportOptions(arguments=arguments).parse()
+
+    # Reporting record stats
+    header = "Status report for {0} ({1} to {2}).".format(
+        options.period, options.since,
+        (options.until.date - delta(days=1)).date())
+
+    # Check for user email addresses (command line or config)
+    # Make sure to load the config that's passed in, if one is...
+    emails = options.emails or config.email
+    emails = utils.split(emails, separator=re.compile(r"\s*,\s*"))
+    users = [did.base.User(email=email) for email in emails]
+
+    # Print header and prepare team stats object for data merging
+    utils.eprint(header)
+    team_stats = UserStats(options=options)
+    if options.merge:
+        utils.header("Total Report")
+        utils.item("Users: {0}".format(len(users)), options=options)
+
+    # Check individual user stats
+    for user in users:
+        if options.merge:
+            utils.item(user, 1, options=options)
+        else:
+            utils.header(user)
+
+        user_stats = UserStats(user=user, options=options)
+        user_stats.check()
+        team_stats.merge(user_stats)
+        gathered_stats.append(user_stats)
+
+    # Display merged team report
+    if options.merge or options.total:
+        if options.total:
+            utils.header("Total Report")
+        team_stats.show()
+
+    # Return all gathered stats objects
+    return gathered_stats, team_stats
+
+
+# FIXME: UPDATE API DOCS FOR MAIN()
+def main(arguments=None, config=None, is_logg=None):
+    """
+    Parse arguments for ``did`` and ``idid`` commands.
+
+    Run ``idid`` by setting is_logg = True. Otherwise, main
+    will attempt to generate a ``did`` report.
+
+    Pass optional parameter ``arguments`` as either command line
+    string or list of options. This is mainly useful for testing.
+
+    ``config`` can be passed in as a string to access user defined
+    values for important variables manually. This is mainly useful
+    for testing.
+
+    If being run for ``did`` reporting, main() returns a tuple of the form::
 
         ([user_stats], team_stats)
 
-    with the list of all gathered stats objects.
+    If being run for ``idid`` logg save, main() returns the saved
+    logg string.
+
     """
+    # FIXME: shouldn't these try:excepts be catching
+    # only the ONE function that's expected to possibly raise the
+    # excepted exceptions?
+
+    config = did.base.set_config(config)
+
     try:
         # Parse options, initialize gathered stats
-        options, header = Options().parse(arguments)
-        gathered_stats = []
+        if is_logg:
+            return _run_logg(arguments, config)
+        else:
+            return _run_report(arguments, config)
 
-        # Check for user email addresses (command line or config)
-        emails = options.emails or did.base.Config().email
-        emails = utils.split(emails, separator=re.compile(r"\s*,\s*"))
-        users = [did.base.User(email=email) for email in emails]
-
-        # Print header and prepare team stats object for data merging
-        utils.eprint(header)
-        team_stats = UserStats(options=options)
-        if options.merge:
-            utils.header("Total Report")
-            utils.item("Users: {0}".format(len(users)), options=options)
-
-        # Check individual user stats
-        for user in users:
-            if options.merge:
-                utils.item(user, 1, options=options)
-            else:
-                utils.header(user)
-            user_stats = UserStats(user=user, options=options)
-            user_stats.check()
-            team_stats.merge(user_stats)
-            gathered_stats.append(user_stats)
-
-        # Display merged team report
-        if options.merge or options.total:
-            if options.total:
-                utils.header("Total Report")
-            team_stats.show()
-
-        # Return all gathered stats objects
-        return gathered_stats, team_stats
-
-    except did.base.ConfigFileError as error:
-        utils.info("Create at least a minimum config file {0}:\n{1}".format(
-            did.base.Config.path(), did.base.Config.example().strip()))
-        raise
-
+    # FIXME catch at the level where kerberos is actually known to be used?
     except kerberos.GSSError as error:
         log.debug(error)
         raise did.base.ConfigError(

--- a/did/logg.py
+++ b/did/logg.py
@@ -172,7 +172,9 @@ class Logg(object):
         # get a config file, the default or the one passed in
         config = did.base.get_config(config)
         try:
+            email = config.email
             config = dict(config.section(LOGG_CONFIG_KEY))
+            config['email'] = email
         except did.base.ConfigFileError as err:
             log.warn("Error while loading config: [{0}]".format(err))
             # Don't panic yet if the section doesn't exist ...
@@ -356,6 +358,9 @@ class GitLogg(Logg):
         # Include the record in the git command too
         kwargs['m'] = record
 
+        # Include author
+        kwargs['author'] = self.config['email']
+
         # FIXME: add documentation to describe this config option
         # if gpg key is defined in .config [logg], git will attempt to
         # sign the commits with the provided key
@@ -366,6 +371,7 @@ class GitLogg(Logg):
         try:
             log.debug("Checking out branch: {0}".format(target))
             self._checkout_branch(target)
+            os.environ["GIT_COMMITTER_DATE"] = str(date)
             r = self.logg_repo.git.commit(**kwargs)
 
             if sync_to:

--- a/did/logg.py
+++ b/did/logg.py
@@ -1,0 +1,238 @@
+# coding: utf-8
+# @ Author: "Chris Ward" <cward@redhat.com>
+
+from __future__ import unicode_literals, absolute_import
+
+import ConfigParser
+import getpass
+import os
+from os.path import expanduser
+import re
+
+import git
+
+import did.base
+from did.utils import log
+
+""" Log and save your did's """
+
+"""
+EXPERIMENTAL
+based on psss's https://github.com/psss/did/issues/38#issuecomment-144431647
+
+data store is git repo
+Branch is 'target log'
+Commits are 'logs'
+Commiter and date is present from the git log by default
+ - possible to ammend
+
+store's on (eg) github are easily 'cloneable' (aka, subscribable)
+
+"""
+
+# only git backend supported; not sure why, but I think
+# we might want to extend to support other 'backends' somehow
+SUPPORTED_BACKENDS = ['git']
+URI_RE = re.compile('([\w]*)://(.*)')
+USER = getpass.getuser()
+DEFAULT_ENGINE_DIR = expanduser('~/.did/loggs')
+# TODO: Consider if we should resolve 'user' rather based on config email?
+DEFAULT_ENGINE_PATH = '{0}/did-{1}.git'.format(DEFAULT_ENGINE_DIR, USER)
+DEFAULT_ENGINE_URI = 'git://{0}'.format(DEFAULT_ENGINE_PATH)
+LOGG_CONFIG_KEY = 'logg'
+
+"""
+# EXAMPLE USAGE
+
+    did logg joy yesterday "@psss merged all my PRs! #did #FTW"
+
+# EXAMPLE CONFIG
+
+    [general]
+    email = "Chris Ward" <cward@redhat.com>
+
+    [work]
+    type = logg
+    joy = Joy of the Week
+    tools = Working on Tooling
+
+
+Logg Record can contain
+
+ * any arbitrary text
+ * invidual but related dids can be on a single line separated by semi-colon's
+ * @mention's to reference another user
+ * #tags to include additional reference to shared theme or topic
+
+"""
+
+# FIXME: Add 'bio' 'about me' README.rst to the repo
+# cv
+
+# FIXME: add --expand to enable launcing an editor and taking a longer
+# commit message with deeper explanation of the SUBJ
+
+
+class Logg(object):
+    """ Git did log class for saving did messages locally to git repo """
+    _args = None
+    config = None
+    date = None
+    engine = None
+    logg_repo = None
+    record = None
+    target = None
+
+    def __init__(self, args, config=None):
+        self._args = args or []
+        self._load_config(config)  # sets self.config
+        self._parse_engine()  # sets self.engine
+        self._parse_logg()   # sets self.target, self.record, self.date
+        self._load_repo()    # sets self.logg_repo
+
+    def logg_record(self, target=None, record=None, date=None):
+        """
+        # %> did logg work 2015-01-01 '... bla bla #tag @mention ...'
+        # results in a logg entry in the 'work' datastore for $DATE (by user)
+
+        # author_date = '2015-01-01T01:01:01'
+        # record = 'Did something AMAZING! [#id] #did'
+
+        # info about specifying a specific date for the committ
+        # http://stackoverflow.com/a/3898842/1289080
+        # Each commit has two dates: the author date and the committer date.
+
+        # commit the record and update the commit date to
+        # r.git.commit(m=record, date=author_date, allow_empty=True)
+        """
+        # FIXME: take emails from config (extracted in CLI already)
+        # FIXME: extract out the possible dates and other tokens
+        # FIXME: check that we're using the write dates here...
+        # FIXME: check if it isn't a duplicate... of the previous
+        # and abort usless it's forced
+        #
+        # git date option needs HH:MM:SS +0000 specified too or it will assume
+        # current time values instead of 00:00:00
+        #
+        # When passing this I get a commit on
+        #  Date: Thu Jan 1 09:32:32 2015 +0100
+        # when just passing utcnow() i get
+        #  Date: Sun Oct 11 08:31:51 2015 +0200
+        # according to my clock (CET; +0200) it's Oct 11 10:33:...
+
+        target = target or self.target
+        record = record or self.record
+        date = date or self.date
+        # normalized date format; git expects iso datetime; -micro (.%f)
+        iso = '%Y-%m-%d %H:%M:%S %z'
+        date = unicode(did.base.Date(date, fmt=iso))
+        log.info('Saving did Logg("{0}", "{1}")'.format(target, record))
+        result = self._commit(target, record, date, sync=True)
+        log.info('SUCCESS: \n{0}'.format(result))
+
+    @property
+    def _args_len(self):
+        return len(self._args or [])
+
+    def _commit(self, target, record, date, sync=None):
+        # checkout the target branch, but make sure to return to
+        # pre-commit state after completion (clean-up) ...
+
+        # always sync/backup/merge commits for 'full-audit' "master" branch
+        current = self.logg_repo.active_branch
+        sync_to = 'master' if sync else None
+        try:
+            log.debug("Checking out branch: {0}".format(target))
+            self._checkout_branch(target)
+            r = self.logg_repo.git.commit(m=record, date=date, allow_empty=True)
+            if sync_to:
+                # sync/backup branch (master)
+                log.info(' ... also syncing to: {0}'.format(sync_to))
+                record = '{0} [{1}]'.format(record, target)
+                result_sync = self._commit(sync_to, record, date, sync=False)
+                log.info(' ... ... {0}'.format(result_sync))
+        finally:
+            if self.logg_repo.active_branch != current:
+                log.debug(
+                    " ... cleaning up (git checkout {0}...".format(current))
+                self._checkout_branch(current)
+        return r
+
+    def _check_config(self):
+        pass
+
+    def _check_logg(self):
+        """ Perform additional check for given options for LOG command """
+        if not self._args:
+            raise ValueError("args is empty; try passing something in?")
+        if self._args_len not in (3, 4):
+            raise RuntimeError(
+                "logg cmd invalid; usage: `logg target [YYYY-MM-DD] 'bla bla'`")
+
+    def _checkout_branch(self, branch=None):
+        branch = branch or 'master'
+        # Try to create the target branch
+        try:
+            self.logg_repo.git.checkout(branch, b=True)
+        except git.GitCommandError:
+            # branch already exists, so check it out
+            self.logg_repo.git.checkout(branch)
+
+    def _load_config(self, config=None):
+        try:
+            config = dict(did.base.Config(config).section(LOGG_CONFIG_KEY))
+        except ConfigParser.NoSectionError:
+            # Don't panic if the section doesn't exist; _check_config()
+            # will check the state of config... maybe {} is OK?
+            config = {}
+        self.config = config
+        self._check_config()
+
+    def _load_repo(self):
+        """ """
+        if os.path.exists(self.path):
+            log.info('FOUND {0}'.format(self.path))
+            r = git.Repo(self.path)
+        else:
+            # create the repo if it doesn't already exist
+            log.info('CREATED {0}'.format(self.path))
+            r = git.Repo.init(path=self.path, mkdir=True)
+            r.index.commit("New did repo added")
+        # git checkout
+        self.logg_repo = r
+
+    def _parse_logg(self):
+        """ Parse LOG command """
+        self._check_logg()
+        if self._args_len == 3:
+            target, record = self._args[1:3]
+            date = 'today'  # default
+        else:
+            assert self._args_len == 4
+            target, date, record = self._args[1:4]
+        self.target = target
+        self.record = record.decode('utf-8')
+        self.date = date
+
+        # Require that the user explicitly 'enable' the branch targets
+        # they want to accept loggs for
+        if target not in self.config:
+            raise did.base.ConfigError(
+                'Target ({0}) not tracked; add to config'.format(target))
+
+    def _parse_engine(self):
+        """ """
+        # use the default engine if not specified
+        self.engine = self.config.get('engine') or DEFAULT_ENGINE_URI
+        try:
+            self.backend, self.path = URI_RE.match(self.engine).groups()
+        except TypeError:
+            # bad uri
+            # uri = '{0}://{1}'.format(backend, path)
+            raise TypeError('Invalid uri!')
+
+        # ENGINE CHECK ()
+        # At this time, we only support git as a backend
+        if self.backend not in SUPPORTED_BACKENDS:
+            raise NotImplementedError(
+                "Logg supports only {0} for now.".format(SUPPORTED_BACKENDS))

--- a/did/plugins/bitly.py
+++ b/did/plugins/bitly.py
@@ -29,7 +29,7 @@ from bitly_api import Connection
 
 from did.stats import Stats, StatsGroup
 from did.utils import log, pretty
-from did.base import Config, ReportError, ConfigError
+from did.base import Config, ConfigError
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  bit.ly
@@ -109,8 +109,8 @@ class SavedLinks(Stats):
         '''
         Bit.ly API expect unix timestamps
         '''
-        since = time.mktime(self.options.since.datetime.timetuple())
-        until = time.mktime(self.options.until.datetime.timetuple())
+        since = time.mktime(self.options.since.date.timetuple())
+        until = time.mktime(self.options.until.date.timetuple())
         log.info("Searching for links saved by {0}".format(self.user))
         self.stats = self.parent.bitly.user_link_history(created_after=since,
                                                          created_before=until)

--- a/did/plugins/bitly.py
+++ b/did/plugins/bitly.py
@@ -27,9 +27,9 @@ import time
 
 from bitly_api import Connection
 
+import did.base
 from did.stats import Stats, StatsGroup
 from did.utils import log, pretty
-from did.base import Config, ConfigError
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  bit.ly
@@ -58,7 +58,8 @@ class Bitly(object):
         self.parent = parent
         self.token = token or getattr(parent, 'token')
         if not self.token:
-            raise ConfigError("bitly requires token to be defined in config")
+            raise did.base.ConfigFileError(
+                "bitly requires token to be defined in config")
 
     @property
     def api(self):
@@ -131,12 +132,13 @@ class BitlyStats(StatsGroup):
 
         # Check Request Tracker instance url and custom prefix
         super(BitlyStats, self).__init__(option, name, parent, user)
-        config = dict(Config().section(option))
+        config = dict(self.config.section(option))
 
         try:
             self.token = config["token"]
         except KeyError:
-            raise ConfigError("No token in the [{0}] section".format(option))
+            raise did.base.ConfigFileError(
+                "No token in the [{0}] section".format(option))
 
         self.bitly = Bitly(parent=self)
         # Construct the list of stats

--- a/did/plugins/bugzilla.py
+++ b/did/plugins/bugzilla.py
@@ -404,9 +404,9 @@ class ClosedBugs(Stats):
     def fetch(self):
         log.info(u"Searching for bugs closed by {0}".format(self.user))
         query = {
-            # User is the assignee
-            "field0-0-0": "assigned_to",
-            "type0-0-0": "equals",
+            # Status changed by the user
+            "field0-0-0": "bug_status",
+            "type0-0-0": "changedby",
             "value0-0-0": self.user.email,
             # Status changed to CLOSED
             "field0-1-0": "bug_status",

--- a/did/plugins/gerrit.py
+++ b/did/plugins/gerrit.py
@@ -16,7 +16,8 @@ import urlparse
 
 from did.utils import log, pretty
 from did.stats import Stats, StatsGroup
-from did.base import Config, ReportError, TODAY, Date
+from did.base import ReportError, TODAY, Date
+import did.base
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -114,7 +115,7 @@ class GerritUnit(Stats):
     def __init__(
             self, option, name=None, parent=None, base_url=None, prefix=None):
         self.base_url = base_url if base_url is not None else parent.repo_url
-        self.prefix = prefix if prefix is not None else parent.config['prefix']
+        self.prefix = prefix if prefix is not None else parent.prefix
         self.repo = Gerrit(baseurl=self.base_url, prefix=self.prefix)
         self.since_date = None
 
@@ -364,17 +365,15 @@ class GerritStats(StatsGroup):
     order = 350
 
     def __init__(self, option, name=None, parent=None, user=None):
-        StatsGroup.__init__(self, option, name, parent, user)
-        self.config = dict(Config().section(option))
-        if 'url' not in self.config:
-            raise IOError(
-                'No gerrit URL set in the [{0}] section'.format(option))
-        self.repo_url = self.config['url']
+        super(GerritStats, self).__init__(option, name, parent, user)
+        config = dict(self.config.section(option))
+        self.repo_url = config.get('url')
+        if not self.repo_url:
+            log.warn('No gerrit URL set in the [{0}] section'.format(option))
         log.debug('repo_url = {0}'.format(self.repo_url))
 
-        if "prefix" not in self.config:
-            raise ReportError(
-                "No prefix set in the [{0}] section".format(option))
+        # set custom prefix or use default 'GR' prefix value
+        self.prefix = config.get('prefix') or 'GR'
 
         self.stats = [
             AbandonedChanges(option=option + '-abandoned', parent=self),
@@ -383,4 +382,4 @@ class GerritStats(StatsGroup):
             PublishedDrafts(option=option + '-drafts', parent=self),
             AddedPatches(option=option + '-added-patches', parent=self),
             ReviewedChanges(option=option + '-reviewed', parent=self),
-            ]
+        ]

--- a/did/plugins/gerrit.py
+++ b/did/plugins/gerrit.py
@@ -16,8 +16,7 @@ import urlparse
 
 from did.utils import log, pretty
 from did.stats import Stats, StatsGroup
-from did.base import ReportError, TODAY, Date
-import did.base
+from did.base import TODAY, Date
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/did/plugins/gerrit.py
+++ b/did/plugins/gerrit.py
@@ -13,11 +13,10 @@ Config example::
 import json
 import urllib
 import urlparse
-from datetime import datetime
 
 from did.utils import log, pretty
 from did.stats import Stats, StatsGroup
-from did.base import Config, ReportError, TODAY
+from did.base import Config, ReportError, TODAY, Date
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -123,7 +122,7 @@ class GerritUnit(Stats):
 
     @staticmethod
     def get_gerrit_date(instr):
-        return datetime.strptime(str(instr), '%Y-%m-%d').date()
+        return Date(instr).date
 
     def fetch(self, query_string="", common_query_options=None,
               limit_since=False):
@@ -278,7 +277,6 @@ class AddedPatches(GerritUnit):
                     continue
                 if 'email' not in chg['author']:
                     continue
-                date = self.get_gerrit_date(chg['date'][:10])
                 comment_date = self.get_gerrit_date(chg['date'][:10])
                 if (owner == chg['author']['email'] and
                         comment_date >= self.since_date and

--- a/did/plugins/gerrit.py
+++ b/did/plugins/gerrit.py
@@ -253,7 +253,7 @@ class AddedPatches(GerritUnit):
         tickets = GerritUnit.fetch(
             self, 'owner:{0}+is:closed&q=owner:{0}+is:open'.format(
                 reviewer),
-            '', limit_since=True)
+            '')
         for tck in tickets:
             log.debug("ticket = {0}".format(tck))
             try:
@@ -279,6 +279,8 @@ class AddedPatches(GerritUnit):
                     continue
                 comment_date = self.get_gerrit_date(chg['date'][:10])
                 if (owner == chg['author']['email'] and
+                        '_revision_number' in chg and
+                        chg['_revision_number'] > 1 and
                         comment_date >= self.since_date and
                         'uploaded patch' in chg['message'].lower()):
                     cmnts_by_user.append(chg)

--- a/did/plugins/git.py
+++ b/did/plugins/git.py
@@ -84,8 +84,7 @@ class GitRepo(object):
 class GitCommits(Stats):
     """ Git commits """
     def __init__(self, option, name=None, parent=None, path=None):
-        super(GitCommits, self).__init__(
-            option=option, name=name, parent=parent)
+        super(GitCommits, self).__init__(option, name, parent)
         self.path = path
         self.repo = GitRepo(self.path)
 
@@ -114,8 +113,8 @@ class GitStats(StatsGroup):
 
     def __init__(self, option, name=None, parent=None, user=None):
         name = "Work on {0}".format(option)
-        StatsGroup.__init__(self, option, name, parent, user)
-        for repo, path in did.base.Config().section(option):
+        super(GitStats, self).__init__(option, name, parent, user)
+        for repo, path in self.config.section(option):
             if path.endswith('/*'):
                 try:
                     directories = os.listdir(path[:-1])

--- a/did/plugins/github.py
+++ b/did/plugins/github.py
@@ -18,10 +18,9 @@ __ https://developer.github.com/guides/getting-started/#authentication
 import re
 import json
 import urllib2
-from requests.exceptions import RequestException
 
+import did.base
 from did.utils import log, pretty, listed
-from did.base import Config, ReportError
 from did.stats import Stats, StatsGroup
 
 # Identifier padding
@@ -56,7 +55,7 @@ class GitHub(object):
                 unicode(response.info()).strip()))
         except urllib2.URLError as error:
             log.debug(error)
-            raise ReportError(
+            raise did.base.ReportError(
                 "GitHub search on {0} failed.".format(self.url))
         result = json.loads(response.read())["items"]
         log.debug("Result: {0} fetched".format(listed(len(result), "item")))
@@ -97,7 +96,8 @@ class IssuesCreated(Stats):
         query = "search/issues?q=author:{0}+created:{1}..{2}".format(
             self.user.login, self.options.since, self.options.until)
         self.stats = [
-                Issue(issue) for issue in self.parent.github.search(query)]
+            Issue(issue) for issue in self.parent.github.search(query)]
+
 
 class IssuesClosed(Stats):
     """ Issues closed """
@@ -106,7 +106,7 @@ class IssuesClosed(Stats):
         query = "search/issues?q=assignee:{0}+closed:{1}..{2}".format(
             self.user.login, self.options.since, self.options.until)
         self.stats = [
-                Issue(issue) for issue in self.parent.github.search(query)]
+            Issue(issue) for issue in self.parent.github.search(query)]
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -120,13 +120,13 @@ class GitHubStats(StatsGroup):
     order = 330
 
     def __init__(self, option, name=None, parent=None, user=None):
-        StatsGroup.__init__(self, option, name, parent, user)
-        config = dict(Config().section(option))
+        super(GitHubStats, self).__init__(option, name, parent, user)
+        config = dict(self.config.section(option))
         # Check server url
         try:
             self.url = config["url"]
         except KeyError:
-            raise ReportError(
+            raise did.base.ReportError(
                 "No github url set in the [{0}] section".format(option))
         # Check authorization token
         try:

--- a/did/plugins/idonethis.py
+++ b/did/plugins/idonethis.py
@@ -83,9 +83,8 @@ class IdonethisStatsGroup(StatsGroup):
         super(IdonethisStatsGroup, self).__init__(
             option=option, name=name, parent=parent, user=user)
 
-        self.config = dict(did.base.Config().section(option))
-
-        self.token = self.config.get('token')
+        config = dict(self.config.section(option))
+        self.token = config.get('token')
         if not self.token:
             raise did.base.ConfigError(
                 'No token defined in the [{0}] section'.format(option))

--- a/did/plugins/items.py
+++ b/did/plugins/items.py
@@ -46,7 +46,7 @@ class CustomStats(StatsGroup):
     order = 800
 
     def __init__(self, option, name=None, parent=None, user=None):
-        super(StatsGroup, self).__init__("custom", name, parent, user)
+        super(CustomStats, self).__init__("custom", name, parent, user)
         for section in self.config.sections(kind="items"):
             self.stats.append(ItemStats(
                 option=section, parent=self,

--- a/did/plugins/items.py
+++ b/did/plugins/items.py
@@ -13,7 +13,6 @@ Config example::
 """
 
 from did.utils import item
-from did.base import Config
 from did.stats import Stats, StatsGroup
 
 
@@ -26,11 +25,11 @@ class ItemStats(Stats):
 
     def __init__(self, option, name=None, parent=None):
         # Prepare sorted item content from the config section
-        items = Config().section(option, skip=["type", "header", "order"])
+        items = self.config.section(option, skip=["type", "header", "order"])
         self._items = [
             "{0}{1}".format(value, "" if "-" in value else " - ")
             for _, value in sorted(items, key=lambda x: x[0])]
-        Stats.__init__(self, option, name, parent)
+        super(ItemStats, self).__init__(option, name, parent)
 
     def header(self):
         """ Simple header for custom stats (no item count) """
@@ -47,8 +46,8 @@ class CustomStats(StatsGroup):
     order = 800
 
     def __init__(self, option, name=None, parent=None, user=None):
-        StatsGroup.__init__(self, "custom", name, parent, user)
-        for section in Config().sections(kind="items"):
+        super(StatsGroup, self).__init__("custom", name, parent, user)
+        for section in self.config.sections(kind="items"):
             self.stats.append(ItemStats(
                 option=section, parent=self,
-                name=Config().item(section, "header")))
+                name=self.config.item(section, "header")))

--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -114,10 +114,13 @@ class Issue(object):
         """ True if the issue was commented by given user """
         for comment in self.comments:
             created = dateutil.parser.parse(comment["created"]).date()
-            if (comment["author"]["name"] == user.login and
-                    created >= options.since.date and
-                    created < options.until.date):
-                return True
+            try:
+                if (comment["author"]["name"] == user.login and
+                        created >= options.since.date and
+                        created < options.until.date):
+                    return True
+            except KeyError:
+                pass
         return False
 
 

--- a/did/plugins/logg.py
+++ b/did/plugins/logg.py
@@ -1,0 +1,153 @@
+# coding: utf-8
+"""
+Export did Logg's
+
+Config example::
+
+    [logg]
+    type = logg
+    engine = txt  # alternative: git
+
+    [joy]
+    desc = Joy of the Day
+
+Default git repo store for logg's is ~/.did/loggs/did-$USER.git
+"""
+
+from __future__ import unicode_literals, absolute_import
+
+from dateutil.relativedelta import relativedelta as delta
+import re
+
+import git
+
+import did.base
+import did.logg
+from did.utils import log
+from did.stats import Stats, StatsGroup
+from did.logg import LOGG_CONFIG_KEY
+
+DATE_RE = re.compile('(\d\d\d\d-\d\d-\d\d)')
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Did Logg Stats
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class LoggStats(Stats):
+    """ Logg stats """
+    def fetch(self):
+        stats = []
+
+        author = self.user.email
+        path = self.parent.path
+        # # DATE INCLUSIVE SEARCH IS USED ##
+        # search for anything that has a date that
+        # is equal to or greater than the since date
+        since = self.options.since.date.date()
+        # search for anything that has a date that
+        # is equal to or less than the since date
+        until = self.options.until.date.date()
+        option = self.parent.option
+
+        log.info(
+            "Searching GitLogg {0} entries [> {1} < {2}] for {3}".format(
+                option, since, until, author))
+
+        # complile the search for target topic lines
+        target_re = re.compile(r'\[{0}\]$'.format(option))
+
+        with open(path) as statsf:
+            for l in statsf:
+                l = l.strip()
+
+                # match matching target lines only
+                matched = target_re.search(l)
+                if not matched:
+                    continue
+                matched = DATE_RE.match(l)
+                if not matched:
+                    log.warn('Invalid Logg line encountered: {0}'.format(l))
+                    continue
+                dt = matched.group(1)
+                # grab a a normalized tz aware datetime
+                dt = did.base.Date(dt).date.date()
+                if dt >= since and dt <= until:
+                    stats.append(l)
+        self.stats = stats
+
+
+class GitLoggStats(Stats):
+    """ Git Logg stats """
+    def fetch(self):
+        # FIXME: this needs to be pulled and parsed from config
+        r = git.Repo(self.parent.path)
+        # FIXME: add a '...' to the end of the summary if there
+        # is more text in the body after the SUBJ
+        fmt = '%s'
+
+        # # git search doesn't include the date, only those after... so
+        # # start one before
+        # from git log --help
+        # --since=<date>, --after=<date>
+        #   Show commits more recent than a specific date.
+        since = self.options.since.date.date() - delta(days=1)
+
+        # # git search doesn't include the date, only those before... so
+        # # start one before
+        # --until=<date>, --before=<date>
+        #   Show commits older than a specific date.
+        until = self.options.until.date.date() - delta(days=1)
+
+        author = self.user.email
+        option = self.parent.option
+        log.info(
+            "Searching GitLogg {0} entries [> {1} < {2}] for {3}".format(
+                option, since, until, author))
+
+        try:
+            stats = r.git.log(option, since=since, until=until, pretty=fmt,
+                              author=author)
+        except Exception as err:
+            log.error('Unable to load loggs for {0}: {1}'.format(option, err))
+            self.stats = []
+        else:
+            # remove empty entries
+            _stats = [x.strip() for x in stats.split('\n')]
+            _stats = filter(bool, _stats)
+            self.stats = _stats
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Did Stats Group
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class LoggStatsGroup(StatsGroup):
+    """ Idonethis stats group """
+
+    # Default order
+    order = 1000
+
+    def __init__(self, option, name=None, parent=None, user=None):
+        name = "Loggs {0}".format(option)
+        super(LoggStatsGroup, self).__init__(
+            option=option, name=name, parent=parent, user=user)
+
+        logg_config = dict(self.config.section(LOGG_CONFIG_KEY))
+        config = dict(self.config.section(option))
+
+        # get the name/description of the logg stat, if defined
+        desc = config.get('desc')
+
+        # Detect the type of backend based on the engine uri and
+        # return the StatsGroup expected backend class automatically
+        self.engine = logg_config.get('engine') or did.logg.DEFAULT_ENGINE_URI
+
+        # Determine what type of backend we should load
+        self.backend, self.path = did.logg.Logg._parse_engine(self.engine)
+        StatsCls = GitLoggStats if self.backend == 'git' else LoggStats
+        log.debug(' ... Backend Type: {0}'.format(StatsCls))
+
+        self.stats = [
+            StatsCls(option=option + '-loggs', parent=self, name=desc)
+        ]

--- a/did/plugins/logg.py
+++ b/did/plugins/logg.py
@@ -36,6 +36,7 @@ DATE_RE = re.compile('(\d\d\d\d-\d\d-\d\d)')
 
 class LoggStats(Stats):
     """ Logg stats """
+
     def fetch(self):
         stats = []
 
@@ -79,6 +80,7 @@ class LoggStats(Stats):
 
 class GitLoggStats(Stats):
     """ Git Logg stats """
+
     def fetch(self):
         # FIXME: this needs to be pulled and parsed from config
         r = git.Repo(self.parent.path)
@@ -123,7 +125,7 @@ class GitLoggStats(Stats):
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 class LoggStatsGroup(StatsGroup):
-    """ Idonethis stats group """
+    """ Logg stats group """
 
     # Default order
     order = 1000

--- a/did/plugins/rt.py
+++ b/did/plugins/rt.py
@@ -17,8 +17,8 @@ import urllib
 import urlparse
 import kerberos
 
+import did.base
 from did.utils import log, pretty
-from did.base import ReportError, Config
 from did.stats import Stats, StatsGroup
 
 
@@ -54,7 +54,7 @@ class RequestTracker(object):
         # Perform the request, convert response into lines
         response = connection.getresponse()
         if response.status != 200:
-            raise ReportError(
+            raise did.base.ReportError(
                 "Failed to fetch tickets: {0}".format(response.status))
         lines = [
             line.decode("utf8")
@@ -133,16 +133,16 @@ class RequestTrackerStats(StatsGroup):
 
         # Check Request Tracker instance url and custom prefix
         StatsGroup.__init__(self, option, name, parent, user)
-        config = dict(Config().section(option))
+        config = dict(self.config.section(option))
         try:
             self.url = config["url"]
         except KeyError:
-            raise ReportError(
+            raise did.base.ReportError(
                 "No url in the [{0}] section".format(option))
         try:
             self.prefix = config["prefix"]
         except KeyError:
-            raise ReportError(
+            raise did.base.ReportError(
                 "No prefix set in the [{0}] section".format(option))
 
         # Save Ticket class as attribute to allow customizations by

--- a/did/plugins/rt.py
+++ b/did/plugins/rt.py
@@ -56,9 +56,7 @@ class RequestTracker(object):
         if response.status != 200:
             raise did.base.ReportError(
                 "Failed to fetch tickets: {0}".format(response.status))
-        lines = [
-            line.decode("utf8")
-            for line in response.read().strip().split("\n")[1:]]
+        lines = response.read().decode("utf8").strip().split("\n")[1:]
         log.debug("Tickets fetched:")
         log.debug(pretty(lines))
         return lines

--- a/did/plugins/trello.py
+++ b/did/plugins/trello.py
@@ -44,7 +44,7 @@ import json
 import urllib
 import urllib2
 
-from did.base import Config, ReportError
+import did.base
 from did.utils import log, pretty, listed, split
 from did.stats import Stats, StatsGroup
 
@@ -265,12 +265,12 @@ class TrelloStatsGroup(StatsGroup):
         }
         self._session = None
         self.url = "https://trello.com/1"
-        config = dict(Config().section(option))
+        config = dict(self.config.section(option))
 
         positional_args = ['apikey', 'token']
         if (not set(positional_args).issubset(set(config.keys()))
                 and "user" not in config):
-            raise ReportError(
+            raise did.base.ReportError(
                 "No ({0}) or 'user' set in the [{1}] section".format(
                     listed(positional_args, quote="'"), option))
 

--- a/did/plugins/wiki.py
+++ b/did/plugins/wiki.py
@@ -11,8 +11,8 @@ Config example::
 
 import xmlrpclib
 
+import did.base
 from did.utils import item
-from did.base import Config
 from did.stats import Stats, StatsGroup
 
 
@@ -69,8 +69,8 @@ class WikiStats(StatsGroup):
     order = 700
 
     def __init__(self, option, name=None, parent=None, user=None):
-        StatsGroup.__init__(self, option, name, parent, user)
-        for wiki, url in Config().section(option):
+        super(WikiStats, self).__init__(option, name, parent, user)
+        for wiki, url in self.config.section(option):
             self.stats.append(WikiChanges(
                 option=wiki, parent=self, url=url,
                 name="Updates on {0}".format(wiki)))

--- a/did/plugins/wiki.py
+++ b/did/plugins/wiki.py
@@ -11,14 +11,9 @@ Config example::
 
 import xmlrpclib
 
-import did.base
 from did.utils import item
 from did.stats import Stats, StatsGroup
 
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#  Wiki Stats
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~rom did.utils import item
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Wiki Stats

--- a/did/utils.py
+++ b/did/utils.py
@@ -5,11 +5,12 @@
 from __future__ import unicode_literals, absolute_import
 
 import os
+from pprint import pformat as pretty  # imported, but not used # NOQA
 import re
+import shutil
 import sys
 import logging
 import unicodedata
-from pprint import pformat as pretty
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -390,3 +391,19 @@ class Coloring(object):
 
 # Create the default output logger
 log = Logging('did').logger
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Test Utilities
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+def remove_path(path):
+    # remove a dir/file if it happens to exist
+    if os.path.exists(path):
+        if os.path.isdir(path):
+            # a dir
+            shutil.rmtree(path)
+        else:
+            # a file
+            os.remove(path)
+    assert not os.path.exists(path)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,9 +1,10 @@
 
-================
+=================
     Examples
-================
+=================
 
-Let's have a look at a couple of real-life examples!
+Let's have a look at a couple of real-life examples for ``did``
+and ``idid``
 
 
 Config
@@ -17,10 +18,13 @@ trac, plus my favorite header & footer I'm used to fill manually::
     email = "Petr Šplíchal" <psplicha@redhat.com>
     width = 79
 
+    [joy]
+    type = logg
+    desc = Joy of the Day
+
     [header]
     type = header
     high = Highlights
-    joy = Joy of the week ;-)
 
     [tools]
     type = git
@@ -46,9 +50,9 @@ trac, plus my favorite header & footer I'm used to fill manually::
 Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Here's how available command line options look like with this
-config. Note that ``did`` detects all enabled plugins and creates
-corresponding option groups for each of them::
+Here's how available command line options for ``did`` with this
+config. Note that ``did`` detects all configured plugins and 
+creates corresponding option groups for each of them::
 
     usage: did [this|last] [week|month|quarter|year] [options]
 
@@ -62,8 +66,11 @@ corresponding option groups for each of them::
 
     Header:
       --header-high    Highlights
-      --header-joy     Joy of the week
       --header         All above
+
+    Joy of the Day:
+      --joy-loggs
+      --joy
 
     Bugzilla stats:
       --bz-filed       Bugs filed
@@ -106,6 +113,21 @@ corresponding option groups for each of them::
       --debug          Turn on debugging output, do not catch exceptions
 
 
+Usage for ``idid`` is even simpler::
+
+    usage: idid [today|DATE|...] [topic] 'Logg record' [options]
+
+    optional arguments:
+      -h, --help      show this help message and exit
+      --debug         Turn on debugging output, catch exceptions
+      --quiet         Turn off all logging except errors; no exceptions
+
+    Select:
+      --email EMAILS  User email address(es)
+      --since SINCE   Start date in YYYY-MM-DD format
+      --until UNTIL   End date in YYYY-MM-DD format
+
+
 Week
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -121,6 +143,7 @@ Now it's easy to find out what I was working on during this week::
     * Highlights
 
     * Joy of the week
+        * @cward submitted a bunch of did pull requests! #ftw
 
     * Bugs fixed: 2
         * BZ#1261963 - wrong date format causes traceback
@@ -148,6 +171,23 @@ Now it's easy to find out what I was working on during this week::
     * Plans, thoughts, ideas...
 
     * Status: Green | Yellow | Orange | Red
+
+
+To save additional joys, just run ``idid``::
+
+    > idid joy 'Finished drafting the idid feature'
+    > idid joy yesterday 'Cleaned out my inbox'
+
+To retrieve just the joys you've saved for the week, just run ``did``::
+
+    > did this week --joy
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     Petr Šplíchal <psplicha@redhat.com>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    * Joy of the week
+        * Finished drafting the idid feature
+        * Cleaned out my inbox
 
 
 Tools

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,14 +3,20 @@
     Install
 ===============
 
+Fedora
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In Fedora simply install the package::
+
+    dnf install did
+
+That's it! :-)
+
+
 Copr
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Set up the `did repository`__ and install the tool using yum::
-
-    yum install did
-
-or use dnf which allows to enable the repository directly::
+Set up the `did repository`__ and install the tool using dnf::
 
     dnf copr enable psss/did
     dnf install did

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -21,6 +21,13 @@ base
     :members:
     :undoc-members:
 
+logg
+----
+
+.. automodule:: did.logg
+    :members:
+    :undoc-members:
+
 utils
 -----
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -7,6 +7,13 @@
     :members:
     :undoc-members:
 
+logg
+----
+
+.. automodule:: did.plugins.logg
+    :members:
+    :undoc-members:
+
 bugzilla
 --------
 

--- a/examples/config
+++ b/examples/config
@@ -2,10 +2,17 @@
 email = Petr Splichal <psplicha@redhat.com>
 width = 79
 
+[logg]
+engine = txt
+strict = false
+
+[joy]
+type = logg
+desc = Joy of the day ;-)
+
 [header]
 type = header
 highlights = Highlights
-joy = Joy of the week ;-)
 
 [nitrate]
 type = nitrate

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,7 @@ __desc__ = 'did - What did you do last week, month, year?'
 __scripts__ = ['bin/did', 'bin/idid']
 __irequires__ = [
     'python_dateutil==2.4.2',
-    'urllib2_kerberos',
     'python-bugzilla',  # FIXME: make optional? see __xrequires__
-    'pykerberos',
     'pytz==2015.6',
 ]
 __xrequires__ = {
@@ -46,8 +44,12 @@ __xrequires__ = {
     'bitly': [
         'bitly_api',
     ],
+    'kerberos': [
+        'pykerberos',
+        'urllib2_kerberos',
+    ],
     'logg': [
-        'GitPython==1.0.1'
+        'GitPython==2.0.5'
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,13 @@ __pkgs__ = [
 ]
 __provides__ = ['did']
 __desc__ = 'did - What did you do last week, month, year?'
-__scripts__ = ['bin/did']
+__scripts__ = ['bin/did', 'bin/idid']
 __irequires__ = [
     'python_dateutil==2.4.2',
     'urllib2_kerberos',
     'python-bugzilla',  # FIXME: make optional? see __xrequires__
     'pykerberos',
+    'pytz==2015.6',
 ]
 __xrequires__ = {
     # `install` usage: pip install did[tests,docs]
@@ -44,6 +45,9 @@ __xrequires__ = {
     ],
     'bitly': [
         'bitly_api',
+    ],
+    'logg': [
+        'GitPython==1.0.1'
     ],
 }
 

--- a/tests/plugins/test_bitly.py
+++ b/tests/plugins/test_bitly.py
@@ -7,8 +7,9 @@ import pytest
 
 from bitly_api import BitlyError
 
-import did.cli
 import did.base
+import did.cli
+import did.plugins
 
 BASIC_CONFIG = """
 [general]
@@ -23,9 +24,9 @@ BAD_TOKEN_CONFIG = BASIC_CONFIG + "\ntoken = bad-token"
 OK_CONFIG = BASIC_CONFIG + "\ntoken = 77912602cc1d712731b2d8a2810cf8500d2d0f89"
 
 # one link should be present
-INTERVAL = "--since 2015-10-06 --until 2015-10-07"
+INTERVAL = "--since 2015-10-06 --until 2015-10-07 --bitly"
 # No links should be present
-INTERVAL1 = "--since 2015-10-07 --until 2015-10-08"
+INTERVAL1 = "--since 2015-10-07 --until 2015-10-08 --bitly"
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -42,23 +43,14 @@ def test_missing_token():
     """
     Missing bitly token results in Exception
     """
-    import did
-    did.base.Config(BASIC_CONFIG)
-    # FIXME: is SystemExit really a reasonable exception?
-    # why not let the exception that occured just happen?
-    # why the use of sys.exit?
-    # Testing required that we check for SystemExit exception
-    # even though that's not the actual error that is triggered
-    with pytest.raises(did.base.ConfigError):
-        did.cli.main(INTERVAL)
+    with pytest.raises(did.base.ConfigFileError):
+        did.cli.main(INTERVAL, BASIC_CONFIG)
 
 
 def test_invalid_token():
     """ Invalid bitly token """
-    import did
-    did.base.Config(BAD_TOKEN_CONFIG)
     with pytest.raises(BitlyError):
-        did.cli.main(INTERVAL)
+        did.cli.main(INTERVAL, BAD_TOKEN_CONFIG)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -67,9 +59,7 @@ def test_invalid_token():
 
 def test_bitly_saved():
     """ Check expected saved links are returned """
-    import did
-    did.base.Config(OK_CONFIG)
-    result = did.cli.main(INTERVAL)
+    result = did.cli.main(INTERVAL, OK_CONFIG)
     stats = result[0][0].stats[0].stats[0].stats
     _m = (
         "http://bit.ly/kejbaly2_roreilly_innerwars_reddit - "

--- a/tests/plugins/test_bugzilla.py
+++ b/tests/plugins/test_bugzilla.py
@@ -8,11 +8,14 @@ import did.base
 
 
 CONFIG = """
+[general]
+email = "Chris Ward" <cward@redhat.com>
+
 [bz]
 type = bugzilla
 prefix = BZ
 url = https://partner-bugzilla.redhat.com/xmlrpc.cgi
-"""
+""".strip()
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -21,10 +24,13 @@ url = https://partner-bugzilla.redhat.com/xmlrpc.cgi
 
 def test_bugzilla_linus():
     """ Check bugs filed by Linus :-) """
-    did.base.Config(CONFIG)
-    stats = did.cli.main("""
+    did.base.set_config(CONFIG)
+    cmd = """
         --email torvalds@linux-foundation.org
-        --bz-filed --until today""")[0][0].stats[0].stats[0].stats
+        --since 2008-03-01
+        --until 2008-04-01
+        --bz-filed"""
+    stats = did.cli.main(cmd)[0][0].stats[0].stats[0].stats
     assert any([bug.id == 439858 for bug in stats])
 
 
@@ -34,7 +40,7 @@ def test_bugzilla_linus():
 
 def test_bugzilla_week():
     """ Check all stats for given week """
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main("--email psplicha@redhat.com")
     assert stats
 
@@ -45,20 +51,22 @@ def test_bugzilla_week():
 
 def test_bugzilla_fixed():
     """ Check fixed bugs on BZ#1174186"""
-    did.base.Config(CONFIG)
+    # Pass CONFIG to main directly; let's not rely on module level changes;
+    # we can't predict how they affect future tests that run and expect
+    # default module conditions
     # The first fix was not successfull (bug later moved to ASSIGNED)
     stats = did.cli.main("""
-        --bz-fixed
         --email sbradley@redhat.com
         --since 2015-03-03
-        --until 2015-03-03""")[0][0].stats[0].stats[3].stats
+        --until 2015-03-03
+        --bz-fixed""", CONFIG)[0][0].stats[0].stats[3].stats
     assert not any([bug.id == 1174186 for bug in stats])
     # The second fix was successfull
     stats = did.cli.main("""
-        --bz-fixed
         --email sbradley@redhat.com
         --since 2015-04-16
-        --until 2015-04-16""")[0][0].stats[0].stats[3].stats
+        --until 2015-04-16
+        --bz-fixed""", CONFIG)[0][0].stats[0].stats[3].stats
     assert any([bug.id == 1174186 for bug in stats])
 
 
@@ -68,20 +76,19 @@ def test_bugzilla_fixed():
 
 def test_bugzilla_returned():
     """ Check returned bugs """
-    did.base.Config(CONFIG)
     # Moving bug to ASSIGNED from ON_QA (test on BZ#1174186)
     stats = did.cli.main([
-        "--bz-returned",
         "--email", "David Kutálek <dkutalek@redhat.com>",
         "--since", "2015-04-15",
-        "--until", "2015-04-15"])[0][0].stats[0].stats[4].stats
+        "--until", "2015-04-15",
+        "--bz-returned"], CONFIG)[0][0].stats[0].stats[4].stats
     assert any([bug.id == 1174186 for bug in stats])
     # Moving from NEW is not returning bug (test on BZ#1229704)
     stats = did.cli.main("""
-        --bz-returned
         --email mizdebsk@redhat.com
         --since 2015-06-09
-        --until 2015-06-09""")[0][0].stats[0].stats[4].stats
+        --until 2015-06-09
+        --bz-returned""", CONFIG)[0][0].stats[0].stats[4].stats
     assert not any([bug.id == 1229704 for bug in stats])
 
 
@@ -91,11 +98,10 @@ def test_bugzilla_returned():
 
 def test_bugzilla_closed():
     """ Check closed bugs """
-    did.base.Config(CONFIG)
     stats = did.cli.main([
-        "--bz-closed",
         "--email", "Petr Šplíchal <psplicha@redhat.com>",
         "--since", "2012-12-06",
-        "--until", "2012-12-06"])[0][0].stats[0].stats[7].stats
+        "--until", "2012-12-06",
+        "--bz-closed"], CONFIG)[0][0].stats[0].stats[7].stats
     assert any([bug.id == 862231 for bug in stats])
     assert any(["[duplicate]" in unicode(bug) for bug in stats])

--- a/tests/plugins/test_gerrit.py
+++ b/tests/plugins/test_gerrit.py
@@ -28,18 +28,18 @@ prefix = GR
 
 def test_gerrit_smoke():
     """ Smoke test for all stats """
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main("last week")
     assert stats
 
 
 def test_gerrit_merged():
     """ Check merged changes """
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main([
-        "--gerrit-merged",
         "--since", "2015-08-01",
-        "--until", "2015-08-31"])[0][0].stats[0].stats[1].stats
+        "--until", "2015-08-31",
+        "--gerrit-merged"])[0][0].stats[0].stats[1].stats
     assert any([
         "GR#4347 - Fix jobs.rst" in unicode(change)
         for change in stats])
@@ -47,11 +47,11 @@ def test_gerrit_merged():
 
 def test_gerrit_reviewed():
     """ Check reviewed changes """
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main([
-        "--gerrit-reviewed",
         "--since", "2015-08-01",
-        "--until", "2015-08-31"])[0][0].stats[0].stats[5].stats
+        "--until", "2015-08-31",
+        "--gerrit-reviewed"])[0][0].stats[0].stats[5].stats
     assert any([
         "GR#4380 - Fix memleak" in unicode(change)
         for change in stats])

--- a/tests/plugins/test_git.py
+++ b/tests/plugins/test_git.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals, absolute_import
 import os
 import pytest
 import did.cli
+import did.base
 import did.utils
 
 
@@ -33,25 +34,30 @@ did = {0}
 
 def test_git_smoke():
     """ Git smoke """
-    did.base.Config(CONFIG.format(GIT_PATH))
+    did.base.set_config(CONFIG.format(GIT_PATH))
     did.cli.main(INTERVAL)
+
 
 def test_git_verbosity():
     """ Brief git stats """
-    did.base.Config(CONFIG.format(GIT_PATH))
+    did.base.set_config(CONFIG.format(GIT_PATH))
     did.cli.main(INTERVAL + " --brief")
     did.cli.main(INTERVAL + " --verbose")
 
+
 def test_git_format():
     """ Wiki format """
-    did.base.Config(CONFIG.format(GIT_PATH))
+    did.base.set_config(CONFIG.format(GIT_PATH))
     did.cli.main(INTERVAL + " --format text")
     did.cli.main(INTERVAL + " --format wiki")
 
+
 def test_git_team():
     """ Team report """
-    emails = " --email psplicha@redhat.com,cward@redhat.com"
-    did.base.Config(CONFIG.format(GIT_PATH))
+    emails = " --email psplicha@redhat.com --email cward@redhat.com"
+    # FIXME: single --email with csv doesn't work...
+    #emails = " --email psplicha@redhat.com,cward@redhat.com"
+    did.base.set_config(CONFIG.format(GIT_PATH))
     did.cli.main(INTERVAL + emails)
     did.cli.main(INTERVAL + emails + "--total")
     did.cli.main(INTERVAL + emails + "--merge")
@@ -63,21 +69,23 @@ def test_git_team():
 
 def test_git_regular():
     """ Simple git stats """
-    did.base.Config(CONFIG.format(GIT_PATH))
+    did.base.set_config(CONFIG.format(GIT_PATH))
     stats = did.cli.main(INTERVAL)[0][0].stats[0].stats[0].stats
     assert any([
         "8a725af - Simplify git plugin tests" in stat
         for stat in stats])
 
+
 def test_git_verbose():
     """ Verbose git stats """
-    did.base.Config(CONFIG.format(GIT_PATH))
+    did.base.set_config(CONFIG.format(GIT_PATH))
     stats = did.cli.main(INTERVAL + " --verbose")[0][0].stats[0].stats[0].stats
     assert any(["tests/plugins" in stat for stat in stats])
 
+
 def test_git_nothing():
     """ No stats found """
-    did.base.Config(CONFIG.format(GIT_PATH))
+    did.base.set_config(CONFIG.format(GIT_PATH))
     stats = did.cli.main("--until 2015-01-01")[0][0].stats[0].stats[0].stats
     assert stats == []
 
@@ -88,14 +96,15 @@ def test_git_nothing():
 
 def test_git_invalid():
     """ Invalid git repo """
-    did.base.Config(CONFIG.format("/tmp"))
+    did.base.set_config(CONFIG.format("/tmp"))
     try:
         did.cli.main(INTERVAL)
     except SystemExit:
         raise RuntimeError("Expected warning only")
 
+
 def test_git_non_existent():
     """ Non-existent git repo """
-    did.base.Config(CONFIG.format("i-do-not-exist"))
+    did.base.set_config(CONFIG.format("i-do-not-exist"))
     with pytest.raises(did.base.ReportError):
         did.cli.main(INTERVAL)

--- a/tests/plugins/test_github.py
+++ b/tests/plugins/test_github.py
@@ -31,26 +31,29 @@ login = psss
 
 def test_github_issues_created():
     """ Created issues """
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main(INTERVAL)[0][0].stats[0].stats[0].stats
     assert any([
         "psss/did#017 - What did you do" in unicode(stat) for stat in stats])
 
+
 def test_github_issues_closed():
     """ Closed issues """
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main(INTERVAL)[0][0].stats[0].stats[1].stats
     assert any([
         "psss/did#017 - What did you do" in unicode(stat) for stat in stats])
 
+
 def test_github_invalid_token():
     """ Invalid token """
-    did.base.Config(CONFIG + "\ntoken = bad-token")
+    did.base.set_config(CONFIG + "\ntoken = bad-token")
     with pytest.raises(did.base.ReportError):
         did.cli.main(INTERVAL)
 
+
 def test_github_missing_url():
     """ Missing url """
-    did.base.Config("[gh]\ntype = github")
+    did.base.set_config("[gh]\ntype = github")
     with pytest.raises(did.base.ReportError):
         did.cli.main(INTERVAL)

--- a/tests/plugins/test_idonethis.py
+++ b/tests/plugins/test_idonethis.py
@@ -6,8 +6,8 @@
 from __future__ import unicode_literals, absolute_import
 
 import pytest
-import did.cli
 import did.base
+import did.cli
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Constants
@@ -43,7 +43,7 @@ def test_missing_token():
     Missing apitoken results in Exception
     """
     import did
-    did.base.Config(CONFIG_NO_TOKEN)
+    did.base.set_config(CONFIG_NO_TOKEN)
     with pytest.raises(did.base.ConfigError):
         did.cli.main(INTERVAL)
 
@@ -51,7 +51,7 @@ def test_missing_token():
 def test_invalid_token():
     """ Invalid bitly token """
     import did
-    did.base.Config(CONFIG_BAD_TOKEN)
+    did.base.set_config(CONFIG_BAD_TOKEN)
     with pytest.raises(did.base.ReportError):
         did.cli.main(INTERVAL)
 
@@ -62,7 +62,7 @@ def test_invalid_token():
 
 def test_all_dones():
     """ test that dones stats are queried as expected """
-    did.base.Config(CONFIG_OK)
+    did.base.set_config(CONFIG_OK)
     result = did.cli.main(INTERVAL)
     stats = result[0][0].stats[0].stats[0].stats
     assert any('did done test' in stat for stat in stats)

--- a/tests/plugins/test_jira.py
+++ b/tests/plugins/test_jira.py
@@ -3,7 +3,8 @@
 
 from __future__ import unicode_literals, absolute_import
 
-import sys, os
+import os
+import sys
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), "..", ".."))
 
 import did.cli
@@ -28,49 +29,49 @@ auth_url = https://issues.jboss.org/rest/auth/latest/session
 
 def test_config_gss_auth():
     """  Test default authentication configuration """
-    did.base.Config(CONFIG)
-    stats = JiraStats("jira")
+    did.base.set_config(CONFIG)
+    assert JiraStats("jira")
+
 
 def test_config_basic_auth():
     """  Test basic authentication configuration """
-    did.base.Config(CONFIG +
-                    """
-                    auth_type = basic
-                    auth_username = tom
-                    auth_password = motak
-                    """)
-    stats = JiraStats("jira")
+    _conf = """
+    auth_type = basic
+    auth_username = tom
+    auth_password = motak"""
+    did.base.set_config(CONFIG + _conf)
+    assert JiraStats("jira")
+
 
 def test_config_missing_username():
     """  Test basic auth with missing username """
-    assert_conf_error(CONFIG + "\n"
-                    + "auth_type = basic")
+    assert_conf_error(CONFIG + "\n" "auth_type = basic")
+
 
 def test_config_missing_password():
     """  Test basic auth with missing username """
-    assert_conf_error(CONFIG + "\n"
-                      + "auth_type = basic\n"
-                      + "auth_username = tom\n")
+    assert_conf_error(CONFIG + "\n" "auth_type = basic\n"
+                      "auth_username = tom\n")
+
 
 def test_config_gss_and_username():
     """  Test gss auth with username set """
-    assert_conf_error(CONFIG + "\n"
-                    + "auth_type = gss\n"
-                    + "auth_username = tom\n")
+    assert_conf_error(CONFIG + "\n" "auth_type = gss\n"
+                      "auth_username = tom\n")
+
 
 def test_config_gss_and_password():
     """  Test gss auth with password set """
-    assert_conf_error(CONFIG + "\n"
-                      + "auth_type = gss\n"
-                      + "auth_password = tom\n")
+    assert_conf_error(CONFIG + "\n" "auth_type = gss\n"
+                      "auth_password = tom\n")
+
 
 def assert_conf_error(config, expected_error=ReportError):
     """  Test given configuration and check that given error type is raised """
-    did.base.Config(config)
+    did.base.set_config(config)
     error = None
     try:
-        stats = JiraStats("jira")
+        assert JiraStats("jira")
     except ReportError as e:
         error = e
     assert type(error) == expected_error
-    

--- a/tests/plugins/test_logg.py
+++ b/tests/plugins/test_logg.py
@@ -1,0 +1,72 @@
+# coding: utf-8
+
+from __future__ import unicode_literals, absolute_import
+
+import ConfigParser
+import logging
+import os
+import pytest
+import re
+from datetime import date, timedelta
+
+# simple test that import works
+import did
+
+did.utils.log.setLevel(logging.DEBUG)
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Constants
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+BASE_CONFIG = '''
+[general]
+email = "Chris Ward" <cward@redhat.com>
+
+[joy]
+type = logg
+
+[logg]
+'''.strip()
+# default repo is created in ~/.did/loggs
+# OVERRIDE THE ENGINE PATH so we don't destroy the user's actual
+# db on accident
+
+DEFAULT_ENGINE_PATH = '/tmp/logg.txt'
+GIT_ENGINE_PATH = '/tmp/logg.git'
+
+DEFAULT_ENGINE_URI = 'txt://{0}'.format(DEFAULT_ENGINE_PATH)
+
+_DEFAULT_ENGINE = '{0}\nengine = {1}\njoy = Joy of the Week'
+GOOD_DEFAULT_CONFIG = _DEFAULT_ENGINE.format(BASE_CONFIG, DEFAULT_ENGINE_URI)
+
+_GIT_ENGINE = '{0}\nengine = git://{1}\njoy = Joy of the Week'
+GOOD_GIT_CONFIG = _GIT_ENGINE.format(BASE_CONFIG, GIT_ENGINE_PATH)
+STRICT_GIT_CONFIG = GOOD_GIT_CONFIG + '\nstrict = true'
+
+ARGS_OK_MIN = ["joy", "did logg joy test 1 2 3", '2015-10-21T07:28:00 +0000']
+
+
+INTERVAL = "--since 2015-10-20 --until 2015-10-22"
+
+did.logg.DEFAULT_ENGINE_URI = DEFAULT_ENGINE_URI
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Unit
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+def test_defaule_logg():
+    did.base.set_config(GOOD_DEFAULT_CONFIG)
+    stats = did.cli.main(INTERVAL)[0][0].stats[0].stats[0].stats
+    assert any(["{0} {1} [{2}]".format(ARGS_OK_MIN[2][:10],
+                                       ARGS_OK_MIN[1],
+                                       ARGS_OK_MIN[0]) in stat
+                for stat in stats])
+
+
+def test_git_logg():
+    did.base.set_config(GOOD_GIT_CONFIG)
+    stats = did.cli.main(INTERVAL)[0][0].stats[0].stats[0].stats
+    assert any(["{0}".format(ARGS_OK_MIN[1]) in stat
+                for stat in stats])

--- a/tests/plugins/test_trac.py
+++ b/tests/plugins/test_trac.py
@@ -25,7 +25,7 @@ prefix = FI
 
 def test_trac_smoke():
     """ Smoke test for all stats """
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main("last week")
     assert stats
 
@@ -33,12 +33,13 @@ def test_trac_smoke():
 def test_trac_created():
     """ Check created tickets """
     # Test on: https://fedorahosted.org/fedora-infrastructure/ticket/4891
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main("""
         --email stefw@example.org
-        --trac-created
         --since 2015-09-17
-        --until 2015-09-17""")[0][0].stats[0].stats[0].stats
+        --until 2015-09-17
+        --trac-created""")[0][0].stats[0].stats[0].stats
+
     assert any([
         "FI#4891 - Hosting docs" in unicode(change) for change in stats])
 
@@ -46,11 +47,12 @@ def test_trac_created():
 def test_trac_closed():
     """ Check closed tickets """
     # Test on: https://fedorahosted.org/fedora-infrastructure/ticket/4864
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main("""
         --email smooge@example.org
-        --trac-closed
         --since 2015-08-30
-        --until 2015-08-30""")[0][0].stats[0].stats[3].stats
+        --until 2015-08-30
+        --trac-closed""")[0][0].stats[0].stats[3].stats
+
     assert any([
         "FI#4864 - remove mdomsch" in unicode(change) for change in stats])

--- a/tests/plugins/test_trello.py
+++ b/tests/plugins/test_trello.py
@@ -31,7 +31,7 @@ user = maybelinot
 
 def test_trello_cards_created():
     """ Created cards """
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main(INTERVAL)[0][0].stats[0].stats[0].stats
     print stats
     assert any([
@@ -40,7 +40,7 @@ def test_trello_cards_created():
 
 def test_trello_cards_updated():
     """ Updated cards """
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main(INTERVAL)[0][0].stats[0].stats[1].stats
     print stats
     assert any([
@@ -50,7 +50,7 @@ def test_trello_cards_updated():
 
 def test_trello_cards_closed():
     """ Closed cards """
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main(INTERVAL)[0][0].stats[0].stats[2].stats
     print stats
     assert any([
@@ -60,7 +60,7 @@ def test_trello_cards_closed():
 
 def test_trello_cards_moved():
     """ Moved cards """
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main(INTERVAL)[0][0].stats[0].stats[3].stats
     print stats
     assert any([
@@ -70,7 +70,7 @@ def test_trello_cards_moved():
 
 def test_trello_checklists_checkitem():
     """ Completed Checkitems in checklists """
-    did.base.Config(CONFIG)
+    did.base.set_config(CONFIG)
     stats = did.cli.main(INTERVAL)[0][0].stats[0].stats[4].stats
     print stats
     # print[unicode(stat) for stat in stats]
@@ -81,6 +81,6 @@ def test_trello_checklists_checkitem():
 
 def test_trello_missing_apikey():
     """ Missing username """
-    did.base.Config("[trello]\ntype = trello")
+    did.base.set_config("[trello]\ntype = trello")
     with pytest.raises(did.base.ReportError):
         did.cli.main(INTERVAL)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,10 +2,13 @@
 
 from __future__ import unicode_literals, absolute_import
 
-import pytest
-import datetime
+from datetime import date, datetime
 import did.base
+import pytest
+import pytz
+
 from did.base import Config, ConfigError
+
 
 def test_base_import():
     # simple test that import works
@@ -21,9 +24,11 @@ def test_Config():
     from did.base import Config
     assert Config
 
+
 def test_Config_email():
     config = Config("[general]\nemail = email@example.com\n")
     assert config.email == "email@example.com"
+
 
 def test_Config_email_missing():
     config = Config("[general]\n")
@@ -32,6 +37,7 @@ def test_Config_email_missing():
     config = Config("[missing]")
     with pytest.raises(did.base.ConfigError):
         config.email == "email@example.com"
+
 
 def test_Config_width():
     config = Config("[general]\n")
@@ -44,62 +50,171 @@ def test_Config_width():
 #  Date
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-def test_Date():
+def test_TODAY():
+    from did.base import TODAY
+
+    d = TODAY.date()
+    _d = datetime.utcnow().replace(tzinfo=pytz.utc).date()
+    assert d == _d
+
+
+def test_import_Date():
     from did.base import Date
     assert Date
 
 
+def test_Date_type_handling():
+    from did.base import Date
+
+    # clearly not dates
+    BAD_DATES = [int(1), 'BAD DATE']
+    for bad in BAD_DATES:
+        with pytest.raises(did.base.OptionError):
+            Date(bad)
+
+    # Date, no timezone or time even
+    D_today = date(2015, 1, 1)
+    d_today = '2015-01-01'
+    assert unicode(Date(d_today)) == d_today
+    assert unicode(Date(D_today)) == d_today
+    # should always have utc timezone attached
+    assert Date(d_today).date.tzinfo == pytz.utc
+
+    # UTC
+    DT_today_utc = datetime(2015, 1, 1, 0, 0, 0, tzinfo=UTC)
+    dt_today_utc = '2015-01-01 00:00:00.000 +0000'
+    assert unicode(Date(dt_today_utc)) == d_today
+    # should always have utc timezone attached
+    # so this is the last time we test for it since it's been found 2x already
+    assert Date(dt_today_utc).date.tzinfo == pytz.utc
+
+    # UTC using 'T' instead of ' ' (space) between date and time
+    dt_today_utc = '2015-01-01T00:00:00.000 +0000'
+    #                         ^
+    assert unicode(Date(dt_today_utc)) == d_today
+    DT_today_utc = datetime(2015, 1, 1, 0, 0, 0, tzinfo=UTC)
+    # Try with datetime
+    assert unicode(Date(DT_today_utc)) == d_today
+
+    # CET
+    DT_today_cet = datetime(2015, 1, 1, 0, 0, 0, tzinfo=CET)
+    dt_today_cet = '2015-01-01 00:00:00.000 +0200'
+    d_today_UTC_from_CET = '2014-12-31'
+    assert unicode(Date(dt_today_cet)) == d_today_UTC_from_CET
+    assert unicode(Date(DT_today_cet)) == d_today_UTC_from_CET
+
+    # UNSPECIFIED timezone (assumed UTC)
+    DT_today_x = datetime(2015, 1, 1, 0, 0, 0)
+    dt_today_x = '2015-01-01 00:00:00'
+    assert unicode(Date(dt_today_x)) == d_today
+    assert unicode(Date(DT_today_x)) == d_today
+
+    # CET specific time, 12:00:00
+    dt_today_noon_cet = '2015-01-01 12:00:00 +0200'
+    iso = '%Y-%m-%d %H:%M:%S %z'
+
+    _DT = unicode(Date(dt_today_noon_cet, fmt=iso))
+    dt_today_noon_cet_as_utc = '2015-01-01 10:00:00 +0000'
+    assert _DT == dt_today_noon_cet_as_utc
+
+
 def test_Date_period():
     from did.base import Date
-    did.base.TODAY = datetime.date(2015, 10, 3)
-    # This week
-    for argument in ["", "week", "this week"]:
-        since, until, period = Date.period(argument)
-        assert unicode(since) == "2015-09-28"
-        assert unicode(until) == "2015-10-05"
-        assert period == "this week"
-    # Last week
-    for argument in ["last", "last week"]:
-        since, until, period = Date.period(argument)
-        assert unicode(since) == "2015-09-21"
-        assert unicode(until) == "2015-09-28"
-        assert period == "the last week"
-    # This month
-    for argument in ["month", "this month"]:
-        since, until, period = Date.period(argument)
-        assert unicode(since) == "2015-10-01"
-        assert unicode(until) == "2015-11-01"
-        assert period == "this month"
-    # Last month
-    for argument in ["last month"]:
-        since, until, period = Date.period(argument)
-        assert unicode(since) == "2015-09-01"
-        assert unicode(until) == "2015-10-01"
-        assert period == "the last month"
-    # This quarter
-    for argument in ["quarter", "this quarter"]:
-        since, until, period = Date.period(argument)
-        assert unicode(since) == "2015-09-01"
-        assert unicode(until) == "2015-12-01"
-        assert period == "this quarter"
-    # Last quarter
-    for argument in ["last quarter"]:
-        since, until, period = Date.period(argument)
-        assert unicode(since) == "2015-06-01"
-        assert unicode(until) == "2015-09-01"
-        assert period == "the last quarter"
-    # This year
-    for argument in ["year", "this year"]:
-        since, until, period = Date.period(argument)
-        assert unicode(since) == "2015-03-01"
-        assert unicode(until) == "2016-03-01"
-        assert period == "this fiscal year"
-    # Last year
-    for argument in ["last year"]:
-        since, until, period = Date.period(argument)
-        assert unicode(since) == "2014-03-01"
-        assert unicode(until) == "2015-03-01"
-        assert period == "the last fiscal year"
+    # WARN: THIS EFFECTS OTHER TESTS! THIS IS NOT AN
+    # ISSOLATED UPDATE; IT BROKE TESTS; RESETTING BACK
+    # TO ORIGINAL STATE AT THE END NOW
+    try:
+        _TODAY = did.base.TODAY
+        did.base.TODAY = date(2015, 10, 3)
+        # This week
+        for argument in ["", "week", "this week"]:
+            since, until, period = Date.period(argument)
+            assert unicode(since) == "2015-09-28"
+            assert unicode(until) == "2015-10-05"
+            assert period == "this week"
+        # Last week
+        for argument in ["last", "last week"]:
+            since, until, period = Date.period(argument)
+            assert unicode(since) == "2015-09-21"
+            assert unicode(until) == "2015-09-28"
+            assert period == "the last week"
+        # This month
+        for argument in ["month", "this month"]:
+            since, until, period = Date.period(argument)
+            assert unicode(since) == "2015-10-01"
+            assert unicode(until) == "2015-11-01"
+            assert period == "this month"
+        # Last month
+        for argument in ["last month"]:
+            since, until, period = Date.period(argument)
+            assert unicode(since) == "2015-09-01"
+            assert unicode(until) == "2015-10-01"
+            assert period == "the last month"
+        # This quarter
+        for argument in ["quarter", "this quarter"]:
+            since, until, period = Date.period(argument)
+            assert unicode(since) == "2015-09-01"
+            assert unicode(until) == "2015-12-01"
+            assert period == "this quarter"
+        # Last quarter
+        for argument in ["last quarter"]:
+            since, until, period = Date.period(argument)
+            assert unicode(since) == "2015-06-01"
+            assert unicode(until) == "2015-09-01"
+            assert period == "the last quarter"
+        # This year
+        for argument in ["year", "this year"]:
+            since, until, period = Date.period(argument)
+            assert unicode(since) == "2015-03-01"
+            assert unicode(until) == "2016-03-01"
+            assert period == "this fiscal year"
+        # Last year
+        for argument in ["last year"]:
+            since, until, period = Date.period(argument)
+            assert unicode(since) == "2014-03-01"
+            assert unicode(until) == "2015-03-01"
+            assert period == "the last fiscal year"
+    finally:
+        # RESET the did.base module state back to original...
+        did.base.TODAY = _TODAY
+
+
+def test_Date_format():
+    from did.base import Date
+
+    d = '2015-01-01'
+    dt = '2015-01-01 00:00:00'
+    dtz = '2015-01-01 00:00:00 +0000'
+    dtz_cet = '2015-01-01 00:00:00 +0200'
+    # since we're 2 hours ahead, in UTC we're 2 behind
+    dtz_cet_utc = '2014-12-31 22:00:00 +0000'
+    d_cet_utc = '2014-12-31'
+
+    # Default format will return the date in YYYY-MM-DD form
+    # after date conversion from defined timezone to UTC, if
+    # timezone is set on the incoming date value.
+    assert str(Date(d)) == d
+    assert str(Date(dt)) == str(d)
+    assert str(Date(dtz)) == str(d)
+    assert str(Date(dtz_cet)) == str(d_cet_utc)
+
+    # different formats should all work as strftime() expects
+    fmt = '%Y'
+    assert str(Date(d, fmt=fmt)) == '2015'
+    fmt = '%Y-%m-%d'
+    assert str(Date(d, fmt=fmt)) == d
+    fmt = '%Y-%m-%d %H:%M:%S'
+    assert str(Date(dt, fmt=fmt)) == dt
+    fmt = '%Y-%m-%d %H:%M:%S %z'
+    assert str(Date(dt, fmt=fmt)) == dtz
+    assert str(Date(d, fmt=fmt)) == dtz
+
+    # unicode works as expected
+    assert unicode(Date('2015-01-01')) == unicode(d)
+
+    # specify timezone
+    iso = '%Y-%m-%d %H:%M:%S %z'
+    assert unicode(Date(dtz_cet, fmt=iso)) == dtz_cet_utc
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,11 +3,15 @@
 from __future__ import unicode_literals, absolute_import
 
 from datetime import date, datetime
+
 import did.base
 import pytest
 import pytz
 
 from did.base import Config, ConfigError
+
+UTC = pytz.utc
+CET = pytz.timezone('CET')
 
 
 def test_base_import():
@@ -19,11 +23,6 @@ def test_base_import():
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Config
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-def test_Config():
-    from did.base import Config
-    assert Config
-
 
 def test_Config_email():
     config = Config("[general]\nemail = email@example.com\n")
@@ -245,7 +244,7 @@ def test_User():
     user = User("some@email.org")
     assert user.email == "some@email.org"
     assert user.login == "some"
-    assert user.name == None
+    assert user.name is None
     assert unicode(user) == "some@email.org"
 
     # Full email format
@@ -273,13 +272,15 @@ def test_User():
     assert user.login == "bzlogin"
 
     # Custom email alias in config section
-    Config(config="[bz]\ntype = bugzilla\nemail = bugzilla@email.org")
+    config = "[bz]\ntype = bugzilla\nemail = bugzilla@email.org"
+    did.base.set_config(config)
     user = User("some@email.org", stats="bz")
     assert user.email == "bugzilla@email.org"
     assert user.login == "bugzilla"
 
     # Custom login alias in config section
-    Config(config="[bz]\ntype = bugzilla\nlogin = bzlogin")
+    config = "[bz]\ntype = bugzilla\nlogin = bzlogin"
+    did.base.set_config(config)
     user = User("some@email.org", stats="bz")
     assert user.login == "bzlogin"
 
@@ -287,7 +288,6 @@ def test_User():
     user = User("some@email.org; bz: bzlogin")
     clone = user.clone("bz")
     assert clone.login == "bzlogin"
-
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,16 +1,15 @@
 # coding: utf-8
+# @ Author: "Chris Ward" <cward@redhat.com>
+
 """ Tests for the command line script """
 
 from __future__ import unicode_literals, absolute_import
 
 import os
 import re
+import sys
+import tempfile
 import pytest
-
-import did.cli
-import did.base
-import did.utils
-
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Constants
@@ -18,21 +17,211 @@ import did.utils
 
 # Prepare path and config examples
 PATH = os.path.dirname(os.path.realpath(__file__))
-MINIMAL = did.base.Config.example()
+# copy/paste from did.base.Config.example()
+MINIMAL = "[general]\nemail = Name Surname <email@example.org>\n"
 EXAMPLE = "".join(open(PATH + "/../examples/config").readlines())
 # Substitute example git paths for real life directories
 EXAMPLE = re.sub(r"\S+/git/[a-z]+", PATH, EXAMPLE)
+GIT_ENGINE_PATH = '/tmp/logg.git'
+
+# Logg configs
+BASE_CONFIG = '''
+[general]
+email = "Chris Ward" <cward@redhat.com>
+'''.strip()
+
+LOG_CONFIG = BASE_CONFIG + '\n\n' + '''
+[logg]
+type = logg
+'''.strip()
+
+# default repo is created in ~/.did/loggs
+# OVERRIDE THE ENGINE PATE so we don't destroy the user's actual
+# db on accident
+DEFAULT_ENGINE_PATH = '/tmp/logg.txt'
+GIT_ENGINE_PATH = '/tmp/logg.git'
+
+_DEFAULT_ENGINE = '\n{0}\nengine = txt://{1}\njoy = Joy of the Week'
+GOOD_LOG_CONFIG = _DEFAULT_ENGINE.format(LOG_CONFIG, DEFAULT_ENGINE_PATH)
+
+_GIT_ENGINE = '{0}\nengine = git://{1}\njoy = Joy of the Week'
+GOOD_GIT_CONFIG = _GIT_ENGINE.format(LOG_CONFIG, GIT_ENGINE_PATH)
+STRICT_GIT_CONFIG = GOOD_GIT_CONFIG + '\nstrict = true'
+NOT_STRICT_GIT_CONFIG = GOOD_GIT_CONFIG + '\nstrict = false'
+
+_logg = "did logg joy test 1 2 3"
+_date = "2015-10-21T07:28:00 +0000"
+ARGS_OK_MIN = [_date, "joy", _logg]
+ARGS_TOPIC_NO_CONFIG = [_date, "not_in_config", _logg]
+ARGS_NO_DATE = ["joy", _logg]
+ARGS_NO_DATE_NO_TOPIC = [_logg]
+
+RESULT_OK_MIN = "2015-10-21 did logg joy test 1 2 3 [joy]"
+# NOTE git version 1.8 doesn't include the Date: ... line
+# git 2.4 does
+# FIXME: conditionally check the line according to git version
+#RESULT_OK_GIT = re.compile(r'\[joy \w+\] did logg joy test 1 2 3\n '
+#                           'Date: Wed Oct 21 07:28:00 2015 \+0000')
+RESULT_OK_GIT = re.compile(r'\[joy \w+\] did logg joy test 1 2 3')
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#  Tests
+#  did Test Environment Set-up
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# OVERRIDE DEFAULT DID CONFIG TO AVOID USING USER'S PERSONAL CONFIG FILE
+tmpd = tempfile.mkdtemp()
+os.environ['DID_DIR'] = tmpd
+
+TMP_CONFIG = os.path.join(tmpd, 'config')
+
+import did.cli
+
+import did.base
+did.base.set_config(path=TMP_CONFIG)
+
+import did.logg
+# avoid using the default engine dir in case user has something there...
+did.logg.DEFAULT_ENGINE_DIR = tmpd
+
+# We are running pytest, so there will be args present
+# sys.argv which need to be removed to simulate an actual
+# exec of did from the cli since the parser falls back to check
+# args in sys.argv because of the use of argparser's argparse
+# command in did.cli
+# ...
+# opt, arg = self.parser.parse_known_args(arguments)
+# ...
+cmd = sys.argv[0]
+assert 'py' in cmd and 'test' in cmd
+
+fake_argv = ['/bin/did']
+sys.argv = fake_argv
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Utils
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+def check_gitlogg_commit_k(x, config=GOOD_GIT_CONFIG):
+    # check the expected number of commits have been made
+    l = did.logg.GitLogg(config=config)
+    commits = list(l.logg_repo.iter_commits())
+    assert len(commits) == x
+
+
+def clean_git():
+    did.utils.remove_path(GIT_ENGINE_PATH)
+    assert not os.path.exists(GIT_ENGINE_PATH)
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Main
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# NOTE: and calls to main() will auto set did.base.DID_CONFIG!
+
+def test_default_no_args_cli():
+    did.utils.remove_path(GIT_ENGINE_PATH)
+
+    # when config is None did defaults to using did.base.CONFIG
+    # default config path and depending on if this config file exists or not
+    # did might print out a default report
+    # Since this is a test, we want to avoid using the default did config
+    # though just in case the testing user is running in his 'production' env
+
+    # We changed the did.base.CONFIG to a random temporary directory in the
+    # header. See line 66 or so...
+
+    # loading from a file that doesn't exist should cause did to except
+    with pytest.raises(did.base.ConfigFileError):
+        did.cli.main()
+
+    # touch the config file, now when we run it again,
+    with open(TMP_CONFIG, 'w') as f:
+        f.write('')
+    did.base.set_config(path=TMP_CONFIG)
+    # it will still crash because of an invalid conf (missing general section)
+    with pytest.raises(did.base.ConfigFileError):
+        did.cli.main()
+
+    # include the minimum config [general] section with email = ...
+    # which should now make main() pass
+    with open(TMP_CONFIG, 'w') as f:
+        f.write(BASE_CONFIG)
+    did.base.set_config(path=TMP_CONFIG)
+    did.cli.main()
+
+    did.utils.remove_path(TMP_CONFIG)
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Logg
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+def test_default_logg():
+    clean_git()
+    r = did.cli.main(ARGS_OK_MIN, GOOD_LOG_CONFIG, is_logg=True)
+    assert os.path.exists(DEFAULT_ENGINE_PATH)
+    assert r == RESULT_OK_MIN
+
+
+def test_default_git_logg():
+    clean_git()
+    r = did.cli.main(ARGS_OK_MIN, GOOD_GIT_CONFIG, is_logg=True)
+    assert os.path.exists(GIT_ENGINE_PATH)
+    assert RESULT_OK_GIT.search(r)
+    check_gitlogg_commit_k(2)
+
+
+def test_topic_not_configed():
+    clean_git()
+    # running this should be OK by default (strict == False)
+    did.cli.main(ARGS_TOPIC_NO_CONFIG, GOOD_GIT_CONFIG, is_logg=True)
+    did.cli.main(ARGS_TOPIC_NO_CONFIG, NOT_STRICT_GIT_CONFIG, is_logg=True)
+    # but with strict == True, we have an exception
+    with pytest.raises(did.base.ConfigError):
+        did.cli.main(ARGS_TOPIC_NO_CONFIG, STRICT_GIT_CONFIG, is_logg=True)
+    check_gitlogg_commit_k(3)
+
+
+def test_logg_api():
+    clean_git()
+    # running this should be OK by default (strict == False)
+    r = did.cli.main(ARGS_NO_DATE, GOOD_GIT_CONFIG, is_logg=True)
+    # %d comes back as 01 but git doesn't zero-pad the days
+    # so on a day like first of november %d is 01 but git shows just 1
+    assert re.match('\[joy \w+\]', r)
+
+    # git version 1.8 doesn't include the Date: ... string in the summary
+    # git version 2.4 does; FIXME: need to conditionally check this depending
+    # on git version installed ...
+    #now = did.base.Date().date.strftime("%a %b")
+    #assert re.search(now, r)
+
+    # strict = False by default, so this shouldn't fail
+    r = did.cli.main(ARGS_NO_DATE_NO_TOPIC, GOOD_GIT_CONFIG, is_logg=True)
+
+    # test that the target topic is 'unsorted'
+    assert re.match('\[unsorted \w+\]', r)
+
+    # this fails since
+    # 'unsorted' isn't defined in config
+    check_gitlogg_commit_k(3)
+
+
+# with pytest.raises(did.base.OptionError):
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Report
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 
 def test_help_minimal():
     """ Help message with minimal config """
-    did.base.Config(config=MINIMAL)
     with pytest.raises(SystemExit):
-        did.cli.main(["--help"])
+        did.cli.main(["--help"], MINIMAL)
+
 
 def test_help_example():
     """ Help message with example config """
@@ -40,16 +229,16 @@ def test_help_example():
     with pytest.raises(SystemExit):
         did.cli.main(["--help"])
 
+
 def test_invalid_arguments():
     """ Complain about invalid arguments """
-    did.base.Config(config=MINIMAL)
     for argument in ["a", "b", "c", "something"]:
         with pytest.raises(did.base.OptionError):
-            did.cli.main(argument)
+            did.cli.main(argument, MINIMAL)
+
 
 def test_invalid_date():
     """ Complain about invalid arguments """
-    did.base.Config(config=MINIMAL)
     for argument in ["--since x", "--since 2015-16-17"]:
         with pytest.raises(did.base.OptionError):
-            did.cli.main(argument)
+            did.cli.main(argument, MINIMAL)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,6 @@ MINIMAL = "[general]\nemail = Name Surname <email@example.org>\n"
 EXAMPLE = "".join(open(PATH + "/../examples/config").readlines())
 # Substitute example git paths for real life directories
 EXAMPLE = re.sub(r"\S+/git/[a-z]+", PATH, EXAMPLE)
-GIT_ENGINE_PATH = '/tmp/logg.git'
 
 # Logg configs
 BASE_CONFIG = '''
@@ -113,6 +112,13 @@ def check_gitlogg_commit_k(x, config=GOOD_GIT_CONFIG):
 def clean_git():
     did.utils.remove_path(GIT_ENGINE_PATH)
     assert not os.path.exists(GIT_ENGINE_PATH)
+    # clear all stale GIT environ variables
+    # WARNING DESTRUCTIVE! but when running tests from Make during pre-commit
+    # git hook, it seems GitPython gets all confused because of env vars...
+    _vars = os.environ.keys()
+    for var in _vars:
+        if var[:3] == 'GIT':
+            os.environ.pop(var)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -187,6 +193,9 @@ def test_topic_not_configed():
 
 def test_logg_api():
     clean_git()
+    print os.getcwd()
+    print '*'*1000
+    print GOOD_GIT_CONFIG
     # running this should be OK by default (strict == False)
     r = did.cli.main(ARGS_NO_DATE, GOOD_GIT_CONFIG, is_logg=True)
     # %d comes back as 01 but git doesn't zero-pad the days

--- a/tests/test_logg.py
+++ b/tests/test_logg.py
@@ -1,0 +1,103 @@
+# coding: utf-8
+
+from __future__ import unicode_literals, absolute_import
+
+import logging
+import os
+import pytest
+import shutil
+
+# import did.base
+
+# simple test that import works
+from did.base import ConfigError
+from did.logg import Logg
+import did.utils
+
+did.utils.log.setLevel(logging.DEBUG)
+
+BASE_CONFIG = '''
+[general]
+email = "Chris Ward" <cward@redhat.com>
+
+[logg]
+type = logg
+engine = git:///tmp/test.git
+'''.strip()
+# default repo is created in ~/.did/loggs
+# OVERRIDE THE ENGINE PATE so we don't destroy the user's actual
+# db on accident
+ENGINE_PATH = '/tmp/test.git'
+
+GOOD_CONFIG = CONFIG = BASE_CONFIG + '\njoy = Joy of the Week'
+
+ARGS_OK_MIN = ["logg", "joy", "'did logg joy test 1 2 3'"]
+
+
+# CAREFUL NOT TO DO ANYTHING IN THE USER'S ACTUAL HOME DIRECTORY!
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Sanity
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+def test_bad_args():
+    from did.logg import Logg
+
+    # Sanity: test good args which shouldn't cause any exception...
+    Logg(['logg', 'joy', 'The most amazing thing happened today...'],
+         config=GOOD_CONFIG)
+
+    # Empty args doesn't fly
+    with pytest.raises(ValueError):
+        Logg(None)
+    with pytest.raises(ValueError):
+        Logg([])
+
+    # These fail because no args or config specified
+    with pytest.raises(ValueError):
+        Logg([], config='')
+    # with Bad Config...
+    with pytest.raises(ConfigError):
+        Logg(['logg', 'joy', 'The most amazing thing happened today...'],
+             config='')
+    # 'joy' target isn't defined in the config
+    with pytest.raises(ConfigError):
+        Logg(['logg', 'joy', 'The most amazing thing happened today...'],
+             config='[logg] \nwork = did it, yes I did!')
+
+    # config is ok, but args isn't
+    with pytest.raises(ValueError):
+        Logg(None, config='[logg]')
+    with pytest.raises(ValueError):
+        Logg([], config='[logg]')
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Unity
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+def test_default_logg():
+    # remove the git repo if it happens to exist;
+    if os.path.exists(ENGINE_PATH):
+        shutil.rmtree(ENGINE_PATH)
+
+    # load a log instance, which should create the repo if it doesn't exist
+    l = Logg(ARGS_OK_MIN, config=GOOD_CONFIG)
+
+    assert os.path.exists(ENGINE_PATH)
+
+    assert l.target == ARGS_OK_MIN[1]
+    assert l.record == ARGS_OK_MIN[2]
+
+    l.logg_record()
+
+    commits = list(l.logg_repo.iter_commits())
+    assert len(commits) == 2
+
+# test
+
+# ... that default branch is created 'master' if no other branches/targets
+# configured in config file
+
+# ... that only branches defined in config or master can be used
+
+#


### PR DESCRIPTION
    Logg - easily track what you did each day
    
    Here's an example .did/config entry:
    
        [joy]
        type = logg
        desc = Joy of the Week
    
        [tools]
        type = logg
        desc = Working on Tooling
    
    Then, an example usage:
    
        idid joy '@psss merged all my pull requests! #FTW'
        did this week
    
        Status report for this week (2015-10-12 to 2015-10-18 16:57:49.980797+00:00).
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         Chris Ward <cward@redhat.com>
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        * Logg stats: 1
         * 2015-10-13 @psss merged all my pull requests! #FTW [joy]
    
    The logg command results in a text file with the loggs stored in plain txt
    
        cat ~/.did/loggs/did-cward.txt
        2015-10-13 X brought me coffee from Italy! #truelove
    
    If you specify 'engine' in the config to point to a git repo you can use a
    git repo with branches as topics as the 'backend' for saving the logs.
    
        [logg]
        engine = git
    
        [joy]
        ...
    
    The same commands above will result in the following git repo, assuming
    you have the necessary GitPython dependencies installed
    
        # config points to git backend
        idid joy '@X brought me coffee from Italy! #ilovemonday'
        cd ~/.did/loggs/did-cward.git/
        git log
        commit 19e4013edd3ccfd52bfe47e9565e6cc03b19f30c
        Author: Chris Ward <cward@redhat.com>
        Date:   Tue Oct 13 19:05:18 2015 +0200
            @X brought me coffee from Italy! #ilovemonday [joy]
    
        commit 60e82b479e9e8792394c7adafca3c44616444496
        Author: Chris Ward <cward@redhat.com>
        Date:   Tue Oct 13 19:05:17 2015 +0200
            New did repo added
    
    It's possible to also save to topic branches that are not
    yet configured, however they won't be available for did reports
    
    Longer form messages can be included as well when using Git
    engine backend, in the same form that a standard git message
    can be Summary + Body separated by a empty line. Use --
    as the 'logg msg' to launch your favorit editor for this. eg::
    
        idid joy --   # launches VIM by default
    
    Additionally, when using Git engine backend it's possible to
    sign your commits by adding your gpg hash to the config. See
    ``did.plugins.logg`` docs for more details.
    
    Some refactoring of was done:
    * main() is split into _run_report (did) and _run_logg (idid)
    * common arguments between did and idid now in parent class Options
    * did and idid custom arguments in subclasses [Report,Logg]Options
    * Some exceptions are now caught where they're actually raised
    * Single instance of Config() is loaded and shared instead of
      calling Config() everywhere a bunch of times
    * Use super() rather than calling the parent class __init__ direct
    * argument order for did.cli.main() matters now; all plugins tests
      updated
      BAD: --bitly --since ... --until ...
      GOOD: --since ... --until ... --bitly
    * some pep8 compliance fixes (eg, braket alignment)
    
    New command: idid
    New Dependency added: GitPython
    
    Tests have (hopefully) been made more robust, and anyways, updated
    * no more implicit global changes to config files; use set_config()
    * main can now accept raw config string to override file based config
    
    There are a few non Logg related changes included here too:
    
    * global config can be obtained by calling ``did.base.get_config``
    * global config can be set by calling ``did.base.set_config``
    * ConfigParser converts 'true' and 'false' values to bool()
    * str(``did.base.Date``) prints unicode version of itself
    * custom strftime format can be passed to Date() for custom format
    * Date() can handle more inputs: Date(), 'today', etc
    * new function added: ``did.utils.remove_path``
    
    Known Issues
    * .git/hooks/commit-msg (bash) fails on `make smoke` even though
      `make smoke` standalone works; could be a python virtualenv issue
    * rpm .spec has not been updated to include PythonGit

