### PR TITLE
Do not use limit_since in Gerrit's AddedPatches

### DIFF
--- a/did/plugins/gerrit.py
+++ b/did/plugins/gerrit.py
@@ -254,7 +254,7 @@ class AddedPatches(GerritUnit):
         tickets = GerritUnit.fetch(
             self, 'owner:{0}+is:closed&q=owner:{0}+is:open'.format(
                 reviewer),
-            '', limit_since=True)
+            '')
         for tck in tickets:
             log.debug("ticket = {0}".format(tck))
             try:


### PR DESCRIPTION
Currently, the 'Additional patches added to existing changes' section provided by the `gerrit` plugin only lists patches added to those Gerrit changes which were created within the specified date range. It makes more sense to list all the patches added in that date range, no matter when the respective Gerrit change was created.