### PR TITLE
Add `login` key to github section in example config

### DIFF
--- a/examples/config
+++ b/examples/config
@@ -26,6 +26,7 @@ tests = /home/psss/git/tests/*
 [github]
 type = github
 url = https://api.github.com/
+login = psss
 
 [gerrit]
 type = gerrit


### PR DESCRIPTION
example/config does not illustrate (common) possibility to override
login for particular plugin.

Github is one of those that may likely need this, so let's add it there.
