### PR TITLE
Fix typo in mr.bob example

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -125,7 +125,7 @@ MrBob
 You can use also use `mrbob` to easily create templates to help
 you get started contributing::
 
-    pip install mrbob
+    pip install mr.bob
     mrbob examples/mr.bob/plugin -O ./did/plugins
 
 `mrbob` should have asked you a few questions before creating a


### PR DESCRIPTION
According to [mr.bob documentation](https://mrbob.readthedocs.io/en/latest/userguide.html) and my experiment, the pip package
name is `mr.bob`, not `mrbob`.
