### PR TITLE
Show weeknum in status-report for week period

### DIFF
--- a/did/base.py
+++ b/did/base.py
@@ -302,10 +302,10 @@ class Date(object):
         else:
             if "last" in argument:
                 since, until = Date.last_week()
-                period = "the last week"
+                period = "the last week # " + since.datetime.strftime("%V")
             else:
                 since, until = Date.this_week()
-                period = "this week"
+                period = "this week # " + since.datetime.strftime("%V")
         return since, until, period
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -64,13 +64,13 @@ def test_Date_period():
         since, until, period = Date.period(argument)
         assert unicode(since) == "2015-09-28"
         assert unicode(until) == "2015-10-05"
-        assert period == "this week"
+        assert period == "this week # " + since.datetime.strftime("%V")
     # Last week
     for argument in ["last", "last week"]:
         since, until, period = Date.period(argument)
         assert unicode(since) == "2015-09-21"
         assert unicode(until) == "2015-09-28"
-        assert period == "the last week"
+        assert period == "the last week # " + since.datetime.strftime("%V")
     # This month
     for argument in ["month", "this month"]:
         since, until, period = Date.period(argument)


### PR DESCRIPTION
Petře,

Following pull request adds ISO week number to this/last week period header for better orientation, for example:

$ did this week
Status report for this week # 32 (2016-08-08 to 2016-08-14).

$ did last week
Status report for the last week # 31 (2016-08-01 to 2016-08-07).

Regards,
DJ
