### PR TITLE
Deduplicate gerrit items when merging

### DIFF
--- a/did/plugins/gerrit.py
+++ b/did/plugins/gerrit.py
@@ -42,6 +42,11 @@ class Change(object):
         """ Consistent identifier and subject for displaying """
         return u"{0}#{1} - {2}".format(self.prefix, self.id, self.subject)
 
+    def __eq__(self, other):
+        return self.__unicode__() == other.__unicode__()
+    
+    def __hash__(self):
+        return hash(self.__unicode__())
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Gerrit Stats

--- a/did/stats.py
+++ b/did/stats.py
@@ -103,7 +103,9 @@ class Stats(object):
 
     def merge(self, other):
         """ Merge another stats. """
-        self.stats.extend(other.stats)
+        self.stats = set(self.stats)
+        self.stats.update(set(other.stats))
+        self.stats = list(self.stats)
         if other._error:
             self._error = True
 


### PR DESCRIPTION
When defining account with multiple aliases it happens that gerrit reports the
same item for both aliases. This change fixes this behaviour by using set()
instead of list and thus deduplicating items. To make this work we define **eq**
and **hash** functions in Change Gerrit class.

This could be useful for other plugins as well - when multiple people work on
the same item it is (presumably) enough to report it once and not once for each
person when merging.
