### PR TITLE
Add basic Redmine support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 before_install:
   - "pip install -U pip setuptools virtualenv coveralls"
 install:
-  - "pip install -e .[bitly,kerberos,google]"
+  - "pip install -e .[bitly,kerberos,google,redmine]"
   - "git fetch --unshallow"
 script:
   - "coverage run --source=bin,did -m py.test $CAPTURE tests"

--- a/did/plugins/redmine.py
+++ b/did/plugins/redmine.py
@@ -1,0 +1,104 @@
+# coding: utf-8
+"""
+Redmine stats
+
+Config example::
+
+    [redmine]
+    type = redmine
+    url = https://redmine.example.com/
+    login = <user_id>
+    activity_days = 30
+
+Use ``login`` to set the user id in Redmine.
+See the :doc:`config` documentation for details on using aliases.
+Use ``activity_days`` to override the default 30 days of activity paging,
+this has to match to the server side setting, otherwise the plugin will miss
+entries.
+
+"""
+
+import datetime
+import dateutil
+import feedparser
+
+from did.utils import log
+from did.base import Config, ReportError
+from did.stats import Stats, StatsGroup
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Activity
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+class Activity(object):
+    """ Redmine Activity """
+    def __init__(self, data):
+        self.data = data
+        self.title = data.title
+
+    def __unicode__(self):
+        """ String representation """
+        return u"{0}".format(self.title)
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Stats
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+class RedmineActivity(Stats):
+    """ Redmine Activity Stats"""
+    def fetch(self):
+        log.info(u"Searching for activity by {0}".format(self.user))
+        results = []
+
+        from_date = self.options.until.date
+        while from_date > self.options.since.date:
+            feed_url = '{0}/activity.atom?user_id={1}&from={2}'.format(
+                self.parent.url, self.user.login,
+                from_date.strftime('%Y-%m-%d'))
+            feed = feedparser.parse(feed_url)
+            for entry in feed.entries:
+                updated = dateutil.parser.parse(entry.updated).date()
+                if updated >= self.options.since.date:
+                    results.append(entry)
+            from_date = from_date - self.parent.activity_days
+
+        self.stats = [Activity(activity) for activity in results]
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Stats Group
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+class RedmineStats(StatsGroup):
+    """ Redmine Stats """
+
+    # Default order
+    order = 550
+
+    def __init__(self, option, name=None, parent=None, user=None):
+        name = "Redmine activity on {0}".format(option)
+        super(RedmineStats, self).__init__(
+            option=option, name=name, parent=parent, user=user)
+        StatsGroup.__init__(self, option, name, parent, user)
+        config = dict(Config().section(option))
+        # Check server url
+        try:
+            self.url = config["url"]
+        except KeyError:
+            raise ReportError(
+                "No Redmine url set in the [{0}] section".format(option))
+        try:
+            self.activity_days = datetime.timedelta(config["activity_days"])
+        except KeyError:
+            # 30 is value of activity_days_default
+            self.activity_days = datetime.timedelta(30)
+        # Create the list of stats
+        self.stats = [
+            RedmineActivity(
+                option="{0}-activity".format(option), parent=self,
+                name="Redmine activity on {0}".format(option)),
+            ]

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,9 @@ __xrequires__ = {
     'google': [
         'google-api-python-client',
     ],
+    'redmine': [
+        'feedparser',
+    ],
 }
 
 pip_src = 'https://pypi.python.org/packages/source'

--- a/tests/plugins/test_redmine.py
+++ b/tests/plugins/test_redmine.py
@@ -1,0 +1,38 @@
+# coding: utf-8
+""" Tests for the Redmine plugin """
+
+from __future__ import unicode_literals, absolute_import
+
+import pytest
+import did.cli
+import did.base
+import time
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Constants
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+INTERVAL = "--since 2017-06-12 --until 2017-06-19"
+
+CONFIG = """
+[general]
+email = "Petr Splichal" <psplicha@redhat.com>
+
+[redmine]
+type = redmine
+url = http://projects.theforeman.org
+login = 6558
+"""
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Tests
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+def test_redmine_activity():
+    """ Redmine activity """
+    did.base.Config(CONFIG)
+    option = "--redmine-activity "
+    stats = did.cli.main(option + INTERVAL)[0][0].stats[0].stats[0].stats
+    assert any([
+        "Foreman - Bug #19986 (New): puppetserver fails to restart after installation" in unicode(stat) for stat in stats])


### PR DESCRIPTION
Fixes: #77 

Not using http://python-redmine.readthedocs.org/ because [the API does not expose activities](http://www.redmine.org/issues/22109)