### PR TITLE
Update config option to accept full filepath

### DIFF
--- a/did/base.py
+++ b/did/base.py
@@ -160,7 +160,9 @@ class Config(object):
         filename = "config"
         matched = re.search("--confi?g?[ =](\S+)", " ".join(sys.argv))
         if matched:
-            filename = matched.groups()[0]
+            filepath, filename = os.path.split(matched.groups()[0])
+            if filepath:
+                directory = filepath
         return directory.rstrip("/") + "/" + filename
 
     @staticmethod


### PR DESCRIPTION
### Negative (file not found) examples to show what config filepath was used:
### Without env variable:
```shell
(py2)[mnalband@mnalband work_repo]$ unset DID_DIR
```
#### Default config path:
```shell
(py2)[mnalband@mnalband work_repo]$ did
 ERROR  Unable to read the config file '/home/mnalband/.did/config'.
```
#### Only config filename:
```shell
(py2)[mnalband@mnalband work_repo]$ did --config config2
 ERROR  Unable to read the config file '/home/mnalband/.did/config2'.
```
#### Filepath and filename:
```shell
(py2)[mnalband@mnalband work_repo]$ did --config /tmp/config2
 ERROR  Unable to read the config file '/tmp/config2'.
```

### With env variable:
```
(py2)[mnalband@mnalband work_repo]$ export DID_DIR=/tmp/did
```
#### Default config path:
```shell
(py2)[mnalband@mnalband work_repo]$ did
 ERROR  Unable to read the config file '/tmp/did/config'.
```
#### Only config filename:
```shell
(py2)[mnalband@mnalband work_repo]$ did --config config2
 ERROR  Unable to read the config file '/tmp/did/config2'.
```
#### Filepath and filename:
```shell
(py2)[mnalband@mnalband work_repo]$ did --config /tmp/config2
 ERROR  Unable to read the config file '/tmp/config2'.
```

### Positive usage example with filepath and filename
```shell
(py2)[mnalband@mnalband work_repo]$ did --config /tmp/config 
Status report for the week 32 (2017-08-07 to 2017-08-13).

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Maryna Nalbandian <mnalband@redhat.com>
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

* Highlights

* Joy of the week
```