### PR TITLE
Port to python-gssapi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 before_install:
   - "pip install -U pip setuptools virtualenv coveralls"
 install:
-  - "pip install -e .[bitly,kerberos,google]"
+  - "pip install -e .[bitly,gssapi,google]"
   - "git fetch --unshallow"
 script:
   - "coverage run --source=bin,did -m py.test $CAPTURE tests"

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ clean:
 run_docker: build_docker
 	@echo
 	@echo "Please note: this is a first cut at doing a container version as a result; known issues:"
-	@echo "* kerberos auth may not be working correctly"
+	@echo "* GSSAPI auth may not be working correctly"
 	@echo "* container runs as privileged to access the conf file"
 	@echo "* output directory may not be quite right"
 	@echo

--- a/did.spec
+++ b/did.spec
@@ -1,6 +1,6 @@
 Name: did
 Version: 0.10
-Release: 1%{?dist}
+Release: 2%{?dist}
 
 Summary: What did you do last week, month, year?
 License: GPLv2+
@@ -10,7 +10,7 @@ Source: https://github.com/psss/did/releases/download/%{version}/did-%{version}.
 
 BuildArch: noarch
 BuildRequires: python-devel
-Requires: python-kerberos python-nitrate python-dateutil python-urllib2_kerberos python-bugzilla
+Requires: python-gssapi python-nitrate python-dateutil python-urllib2-gssapi python-bugzilla
 %{?el6:Requires: python-argparse}
 
 %description
@@ -43,6 +43,9 @@ install -pm 644 did.1.gz %{buildroot}%{_mandir}/man1
 %license LICENSE
 
 %changelog
+* Mon Feb 19 2018 Robbie Harwood <rharwood@redhat.com> 0.10-2
+- Port to python-gssapi
+
 * Wed Jan 11 2017 Martin Frodl <mfrodl@redhat.com> 0.10-1
 - New plugin for Google Apps
 - Document how to generate documentation locally

--- a/did/cli.py
+++ b/did/cli.py
@@ -12,7 +12,7 @@ from __future__ import unicode_literals, absolute_import
 import re
 import sys
 import argparse
-import kerberos
+import gssapi
 from dateutil.relativedelta import relativedelta as delta
 
 import did.base
@@ -205,7 +205,7 @@ def main(arguments=None):
             did.base.Config.path(), did.base.Config.example().strip()))
         raise
 
-    except kerberos.GSSError as error:
-        log.debug(error)
+    except gssapi.exceptions.GSSError as error:
+        log.debug(error.gen_msg())
         raise did.base.ConfigError(
-            "Kerberos authentication failed. Try kinit.")
+            "GSSAPI authentication failed. Try kinit.")

--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -39,7 +39,7 @@ import urllib
 import urllib2
 import cookielib
 import dateutil.parser
-import urllib2_kerberos
+import urllib_gssapi
 
 from did.utils import log, pretty, listed
 from did.base import Config, ReportError
@@ -254,7 +254,7 @@ class JiraStats(StatsGroup):
                 urllib2.HTTPSHandler(debuglevel=0),
                 urllib2.HTTPRedirectHandler,
                 urllib2.HTTPCookieProcessor(cookie),
-                urllib2_kerberos.HTTPKerberosAuthHandler)
+                urllib_gssapi.HTTPSPNEGOAuthHandler)
 
             log.debug("Connecting to {0}".format(self.auth_url))
             if self.auth_type == 'basic':

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
 	return Mock()
 
-MOCK_MODULES = ['kerberos', 'urllib2_kerberos', 'bitly_api']
+MOCK_MODULES = ['gssapi', 'urllib_gssapi', 'bitly_api']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/examples/dockerfile
+++ b/examples/dockerfile
@@ -1,7 +1,7 @@
 FROM fedora
 MAINTAINER langdon <langdon@fedoraproject.org>
 RUN yum clean all && yum -y update
-RUN yum -y install python python-pip make gcc krb5-devel python-devel python-setuptools python-kerberos python-nitrate python-dateutil python-urllib2_kerberos
+RUN yum -y install python python-pip make gcc krb5-devel python-devel python-setuptools python-gssapi python-nitrate python-dateutil python-urllib-gssapi
 RUN yum clean all
 
 COPY . /opt/did

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,9 @@ __xrequires__ = {
     'bitly': [
         'bitly_api',
     ],
-    'kerberos': [
-        'pykerberos',
-        'urllib2_kerberos',
+    'gssapi': [
+        'gssapi',
+        'urllib_gssapi',
     ],
     'google': [
         'google-api-python-client',


### PR DESCRIPTION
As part of this, migrate any urllib2_kerberos code to urllib-gssapi.

Similar caveats to [psss/python-nitrate#8](https://github.com/psss/python-nitrate/pull/8) apply:

- The test suite for this tool cannot reasonably be run; see #146  and #145 
- There are libraries ([requests-gssapi](https://github.com/pythongssapi/requests-gssapi/), [urllib-gssapi](https://github.com/pythongssapi/urllib-gssapi)) that will speak this protocol for you.  I'm happy to provide a patch for either of those if you would prefer.  This package seems to already use urllib2-kerberos (which I have migrated to urllib-gssapi); I'm happy to migrate the remainder of the code to urllib-gssapi as well.

In both cases, you only perform one round of a SPNEGO handshake.  This means that not all SPNEGO connections will complete - you never validate the server tokens, so mutual auth will always fail.  I'm a bit surprised this works at all.  Using requests-gssapi or urllib-gssapi will handle this problem for you.