### PR TITLE
Don't zero-fill numbers in Jira issue by default

### DIFF
--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -46,7 +46,7 @@ from did.base import Config, ReportError
 from did.stats import Stats, StatsGroup
 
 # Default identifier width
-DEFAULT_WIDTH = 4
+DEFAULT_WIDTH = 0
 
 # Maximum number of results fetched at once
 MAX_RESULTS = 1000


### PR DESCRIPTION
From my observations, Jira itself does not format issues by including
zeroes, so there's no reason for did to do so.