### PR TITLE
Fix long_description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open('README.rst') as readme:
 setup(
     name='did',
     description='did - What did you do last week, month, year?',
-    long_description=readme,
+    long_description=description,
     url='https://github.com/psss/did',
     download_url='https://github.com/psss/did/archive/master.zip',
 


### PR DESCRIPTION
The `long_description` is set to `readme`, which is a closed file handle. I think this was meant to be `description`. I think this PR will fix #161.