### PR TITLE
Add commentCard to trello DEFAULT_FILTERS

### DIFF
--- a/did/plugins/trello.py
+++ b/did/plugins/trello.py
@@ -49,7 +49,7 @@ from did.utils import log, pretty, listed, split
 from did.stats import Stats, StatsGroup
 
 DEFAULT_FILTERS = [
-    "createCard", "updateCard",
+    "commentCard", "createCard", "updateCard",
     "updateCard:idList", "updateCard:closed",
     "updateCheckItemStateOnCard"]
 
@@ -256,6 +256,7 @@ class TrelloStatsGroup(StatsGroup):
             'Boards': {},
             'Lists': {},
             'Cards': {
+                'commentCard': TrelloCards,
                 'updateCard': TrelloCards,
                 'updateCard:closed': TrelloCardsClosed,
                 'updateCard:idList': TrelloCardsMoved,


### PR DESCRIPTION
It is not sufficient to customize the trello plugin 'filters' to
make it display the commentCard objects too, because there is no
mapping for such a card action into a python class.

This change updates the DEFAULT_FILTERS list to include commentCard
and adds the matching filter_map item.