### PR TITLE
Add searching for work in progress Gerrit changes

### DIFF
--- a/did/plugins/gerrit.py
+++ b/did/plugins/gerrit.py
@@ -230,20 +230,19 @@ class SubmitedChanges(GerritUnit):
     """
     def fetch(self):
         log.info(u"Searching for changes opened by {0}".format(self.user))
-        self.stats = GerritUnit.fetch(self, 'status:open', limit_since=True)
+        self.stats = GerritUnit.fetch(self, 'status:open -is:wip',
+            limit_since=True)
         log.debug(u"self.stats = {0}".format(self.stats))
 
-
-class PublishedDrafts(GerritUnit):
-    # curl -s 'https://REPOURL/changes/?q=is:draft'
+class WIPChanges(GerritUnit):
     """
-    Draft changes published
+    Work in progress changes
     """
     def fetch(self):
-        log.info(u"Searching for drafts published by {0}".format(self.user))
-        self.stats = GerritUnit.fetch(self, 'is:draft', limit_since=True)
+        log.info(u"Searching for WIP changes opened by {0}".format(self.user))
+        self.stats = GerritUnit.fetch(self, 'status:open is:wip',
+            limit_since=True)
         log.debug(u"self.stats = {0}".format(self.stats))
-
 
 class AddedPatches(GerritUnit):
     # curl -s 'https://REPOURL\
@@ -389,7 +388,7 @@ class GerritStats(StatsGroup):
             AbandonedChanges(option=option + '-abandoned', parent=self),
             MergedChanges(option=option + '-merged', parent=self),
             SubmitedChanges(option=option + '-submitted', parent=self),
-            PublishedDrafts(option=option + '-drafts', parent=self),
+            WIPChanges(option=option + '-wip', parent=self),
             #AddedPatches(option=option + '-added-patches', parent=self),
             ReviewedChanges(option=option + '-reviewed', parent=self),
             ]


### PR DESCRIPTION
Add support for searching CLs marked as "Work in progress". These are
CLs for which the code review hasn't started yet. The submitted CLs
report is changed to omit these WIP CLs. Additionally, remove support
for drafts ('is:draft') which isn't available in Gerrit anymore and
probably had the same purpose.