### PR TITLE
Fix the reviewed changes report from Gerrit

### DIFF
--- a/did/plugins/gerrit.py
+++ b/did/plugins/gerrit.py
@@ -314,7 +314,7 @@ class ReviewedChanges(GerritUnit):
         self.stats = []
         reviewer = self.user.login
         tickets = GerritUnit.fetch(
-            self, 'reviewer:{0}+is:closed&q=reviewer:{0}+is:open'.format(
+            self, 'reviewer:{0}+-owner:{0}'.format(
                 self.user.login),
             '', limit_since=True)
         for tck in tickets:


### PR DESCRIPTION
Omit owned CLs from the reviewed changes report. All owned CLs appear as
if the owner is a reviewer too, but it doesn't make sense to include
them in this report.