### PR TITLE
Fix for #189

### DIFF
--- a/did/plugins/bugzilla.py
+++ b/did/plugins/bugzilla.py
@@ -271,7 +271,8 @@ class VerifiedBugs(Stats):
     """
     Bugs verified
 
-    Bugs with ``QA Contact`` field set to given user and having
+    Bugs with ``QA Contact`` field set to given user
+    or changed by the given user and having
     their status changed to ``VERIFIED``.
     """
     def fetch(self):
@@ -294,10 +295,33 @@ class VerifiedBugs(Stats):
             "o4": "changedbefore",
             "v4": str(self.options.until)
             }
+        query2 = {
+            # User changed the bug state
+            "f1": "bug_status",
+            "o1": "changedby",
+            "v1": self.user.email,
+            # Status changed to VERIFIED
+            "f2": "bug_status",
+            "o2": "changedto",
+            "v2": "VERIFIED",
+            # Since date
+            "f3": "bug_status",
+            "o3": "changedafter",
+            "v3": str(self.options.since),
+            # Until date
+            "f4": "bug_status",
+            "o4": "changedbefore",
+            "v4": str(self.options.until)
+            }
         self.stats = [
             bug for bug in self.parent.bugzilla.search(
                 query, options=self.options)
             if bug.verified()]
+        id_list = [bug.id for bug in self.stats]
+        for bug in self.parent.bugzilla.search(
+                query2, options=self.options):
+            if bug.id not in id_list and bug.verified():
+                self.stats.append(bug)
 
 
 class ReturnedBugs(Stats):

--- a/tests/plugins/test_bugzilla.py
+++ b/tests/plugins/test_bugzilla.py
@@ -114,3 +114,30 @@ def test_bugzilla_closed():
         "--until", "2012-12-06"])[0][0].stats[0].stats[8].stats
     assert any([bug.id == 862231 for bug in stats])
     assert any(["[duplicate]" in unicode(bug) for bug in stats])
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Verified Bugs
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+def test_bugzilla_verified_chagedby():
+    """ Check verified bugs based on changedby"""
+    did.base.Config(CONFIG)
+    stats = did.cli.main([
+        "--bz-verified",
+        "--email", "<jvavra@redhat.com>",
+        "--since", "2018-03-26",
+        "--until", "2018-03-27"])[0][0].stats[0].stats[5].stats
+    # Bug changed by user
+    assert any([bug.id == 1527935 for bug in stats])
+
+def test_bugzilla_verified_qecontact():
+    """ Check verified bugs based on qe contact"""
+    did.base.Config(CONFIG)
+    stats = did.cli.main([
+        "--bz-verified",
+        "--email", "<desktop-qa-list@redhat.com>",
+        "--since", "2019-02-06",
+        "--until", "2019-02-08"])[0][0].stats[0].stats[5].stats
+    # Bug changed by user
+    assert any([bug.id == 1666809 for bug in stats])
+


### PR DESCRIPTION
Bugzilla verified bug not recognized when different QA Contact
Using the bug state change mail instead of QA contact for searchinng
vefified bugs as QA contact can be a team mailinglist and the query
will not match these.