### PR TITLE
Fix the configuration examples for gerrit, remove #

### DIFF
--- a/did/plugins/gerrit.py
+++ b/did/plugins/gerrit.py
@@ -6,7 +6,7 @@ Config example::
 
     [gerrit]
     type = gerrit
-    url = https://example.org/gerrit/#/
+    url = https://example.org/gerrit/
     prefix = GR
 """
 

--- a/examples/config
+++ b/examples/config
@@ -28,7 +28,7 @@ login = psss
 
 [gerrit]
 type = gerrit
-url = https://example.org/gerrit/#/
+url = https://example.org/gerrit/
 prefix = GR
 
 [gitlab]

--- a/tests/plugins/test_gerrit.py
+++ b/tests/plugins/test_gerrit.py
@@ -17,7 +17,7 @@ email = Dan Callaghan <dcallagh@redhat.com>
 
 [gerrit]
 type = gerrit
-url = https://gerrit.beaker-project.org/#/
+url = https://gerrit.beaker-project.org/
 prefix = GR
 """
 


### PR DESCRIPTION
Apparently the URL format required by gerrit changed long time ago,
but the example still reports the old format.
The trailing # must not be specified in the url configuration key
for gerrit.

Fixes #138.