### PR TITLE
gerrit: add a new configuration key to disable wip queries

### DIFF
--- a/tests/plugins/test_gerrit.py
+++ b/tests/plugins/test_gerrit.py
@@ -55,3 +55,26 @@ def test_gerrit_reviewed():
     assert any([
         "GR#6313 - beaker - Make beah default harness" in unicode(change)
         for change in stats])
+
+
+def test_gerrit_wip():
+    """ Check wip changes """
+    did.base.Config(CONFIG)
+    stats = did.cli.main([
+        "--gerrit-wip",
+        "--since", "2015-05-01",
+        "--until", "2016-10-31"])[0][0].stats[0].stats[3].stats
+    assert any([
+        "GR#4211 - beaker - WIP JSONAPI for system pools" in unicode(change)
+        for change in stats])
+
+
+def test_gerrit_wip_disabled():
+    """ Check wip changes when the wip feature is disabled """
+    CONFIG_NO_WIP = CONFIG + 'wip = False\n'
+    did.base.Config(CONFIG_NO_WIP)
+    stats = did.cli.main([
+        "--gerrit-wip",
+        "--since", "2015-05-01",
+        "--until", "2016-10-31"])[0][0].stats[0].stats[3].stats
+    assert stats == []


### PR DESCRIPTION
Not all gerrit servers support the is:wip search. Trying to search
for it on such servers lead to a 400 error.
A new flag can be added to each server to disable wip-based searches.
The default behavior is unchanged, as hopefully more and more
server will support this feature.
The code provides the groundwork to support more of such feature flags.

Fixes #193.