### PR TITLE
Add last friday command

### DIFF
--- a/did/base.py
+++ b/did/base.py
@@ -296,6 +296,17 @@ class Date(object):
             until = Date("yesterday")
             until.date += delta(days=1)
             period = "yesterday"
+        elif "friday" in argument:
+            since = Date("today")
+            until = Date("today")
+            if "last" in argument:
+                since.date += delta(weekday=FR)
+                until.date += delta(weekday=FR)
+                period = "last friday"
+            else:
+                since.date += delta(weekday=FR(-1))
+                until.date += delta(weekday=FR(-1))
+                period = "next friday"
         elif "year" in argument:
             if "last" in argument:
                 since, until = Date.last_year()

--- a/did/cli.py
+++ b/did/cli.py
@@ -29,7 +29,7 @@ class Options(object):
     def __init__(self, arguments=None):
         """ Prepare the parser. """
         self.parser = argparse.ArgumentParser(
-            usage="did [this|last] [week|month|quarter|year] [options]")
+            usage="did [this|last] [friday|week|month|quarter|year] [options]")
         self._prepare_arguments(arguments)
         self.opt = self.arg = None
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -71,6 +71,12 @@ def test_Date_period():
         assert unicode(since) == "2015-09-21"
         assert unicode(until) == "2015-09-28"
         assert period == "the week 39"
+    # Last Friday
+    for argument in ["last friday"]:
+        since, until, period = Date.period(argument)
+        assert unicode(since) == "2015-10-02"
+        assert unicode(until) == "2015-10-02"
+        assert period == "last friday"
     # This month
     for argument in ["month", "this month"]:
         since, until, period = Date.period(argument)


### PR DESCRIPTION
I report on a daily basis and I miss ability to report last Friday. This should do it, also support next Friday which does not make sense, but it's good to be consistent. Not a pythonist, so take care reviewing.

I wanted to add a more generic "last business day" command but it turns out that it's tough to do business days in plain Python and I do not want to add another dependency because of this. If you want the patch to be Israel-friendly, then I can add also "last sunday" or maybe all the days but that could be little bit noisy.