### PR TITLE
Do not break sorting on merge

### DIFF
--- a/did/stats.py
+++ b/did/stats.py
@@ -101,9 +101,9 @@ class Stats(object):
 
     def merge(self, other):
         """ Merge another stats. """
-        self.stats = set(self.stats)
-        self.stats.update(set(other.stats))
-        self.stats = list(self.stats)
+        for other_stat in other.stats:
+            if other_stat not in self.stats:
+                self.stats.append(other_stat)
         if other._error:
             self._error = True
 


### PR DESCRIPTION
My original code for deduplicating in db503e15 was naive and causes another
minor problem when ordering of reported items get reshuffled by set().

This change makes it a little more conservative and when merging we iterate over
list and only append when merging. This way ordering is preserved better and not
randomized.