### PR TITLE
base.py: Use none interpolation for ConfigParser

### DIFF
--- a/did/base.py
+++ b/did/base.py
@@ -84,7 +84,7 @@ class Config(object):
         # Read the config only once (unless explicitly provided)
         if self.parser is not None and config is None and path is None:
             return
-        Config.parser = configparser.ConfigParser()
+        Config.parser = configparser.ConfigParser(interpolation=None)
         # If config provided as string, parse it directly
         if config is not None:
             log.info("Inspecting config file from string")


### PR DESCRIPTION
When character '%' is used in auth_password, the ConfigParser will raise
InterpolationSyntaxError because the ConfigParser in default interpolation[1]
parses '%' as formatting character.

It will report the error like:
configparser.InterpolationSyntaxError: '%' must be followed by '%' or '(', found: '%'

[1]: https://docs.python.org/3.6/library/configparser.html#interpolation-of-values

Signed-off-by: Han Han <hhan@redhat.com>