### PR TITLE
Add search for approved merge requests in gitlab module

### DIFF
--- a/did/plugins/gitlab.py
+++ b/did/plugins/gitlab.py
@@ -282,6 +282,19 @@ class MergeRequestsClosed(Stats):
             for mr in results]
 
 
+class MergeRequestsApproved(Stats):
+    """ Merge requests approved """
+    def fetch(self):
+        log.info("Searching for Merge requests approved by {0}".format(
+            self.user))
+        results = self.parent.gitlab.search(
+            self.user.login, self.options.since, self.options.until,
+            'MergeRequest', 'approved')
+        self.stats = [
+            MergeRequest(mr, self.parent.gitlab)
+            for mr in results]
+
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Stats Group
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -336,4 +349,7 @@ class GitLabStats(StatsGroup):
             MergeRequestsClosed(
                 option=option + "-merge-requests-closed", parent=self,
                 name="Merge requests closed on {0}".format(option)),
+            MergeRequestsApproved(
+                option=option + "-merge-requests-approved", parent=self,
+                name="Merge requests approved on {0}".format(option)),
             ]

--- a/did/plugins/gitlab.py
+++ b/did/plugins/gitlab.py
@@ -346,10 +346,10 @@ class GitLabStats(StatsGroup):
             MergeRequestsCommented(
                 option=option + "-merge-requests-commented", parent=self,
                 name="Issues commented on {0}".format(option)),
-            MergeRequestsClosed(
-                option=option + "-merge-requests-closed", parent=self,
-                name="Merge requests closed on {0}".format(option)),
             MergeRequestsApproved(
                 option=option + "-merge-requests-approved", parent=self,
                 name="Merge requests approved on {0}".format(option)),
+            MergeRequestsClosed(
+                option=option + "-merge-requests-closed", parent=self,
+                name="Merge requests closed on {0}".format(option)),
             ]

--- a/tests/plugins/test_gitlab.py
+++ b/tests/plugins/test_gitlab.py
@@ -12,7 +12,7 @@ import time
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 INTERVAL = "--since 2017-05-24 --until 2017-05-26"
-APPROVED_INTERVAL = "--since 2021-04-8 --until 2021-04-9"
+APPROVED_INTERVAL = "--since 2021-04-08 --until 2021-04-09"
 
 CONFIG_NOTOKEN = """
 [general]
@@ -69,7 +69,7 @@ def test_gitlab_merge_requests_created():
         for stat in stats])
 
 def test_gitlab_merge_requests_commented():
-    """ Commentsd merge requests """
+    """ Commented merge requests """
     did.base.Config(CONFIG)
     option = "--gitlab-merge-requests-commented "
     stats = did.cli.main(option + INTERVAL)[0][0].stats[0].stats[4].stats
@@ -81,18 +81,19 @@ def test_gitlab_merge_requests_closed():
     """ Closed merge requests """
     did.base.Config(CONFIG)
     option = "--gitlab-merge-requests-closed "
-    stats = did.cli.main(option + INTERVAL)[0][0].stats[0].stats[5].stats
+    stats = did.cli.main(option + INTERVAL)[0][0].stats[0].stats[6].stats
     assert any([
         "did.tester/test-project#001 - Update README.md" in str(stat)
         for stat in stats])
 
 def test_gitlab_merge_requests_approved():
-    """ Closed merge approved """
+    """ Approved merge requests """
     did.base.Config(CONFIG)
     option = "--gitlab-merge-requests-approved "
-    stats = did.cli.main(option + APPROVED_INTERVAL)[0][0].stats[0].stats[6].stats
+    stats = did.cli.main(
+        option + APPROVED_INTERVAL)[0][0].stats[0].stats[5].stats
     assert any([
-        "did.tester/test-project#003 - Use a nice complete sentence for description" in str(stat)
+        "did.tester/test-project#003 - Use a nice complete" in str(stat)
         for stat in stats])
 
 def test_github_invalid_token():

--- a/tests/plugins/test_gitlab.py
+++ b/tests/plugins/test_gitlab.py
@@ -12,6 +12,7 @@ import time
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 INTERVAL = "--since 2017-05-24 --until 2017-05-26"
+APPROVED_INTERVAL = "--since 2021-04-8 --until 2021-04-9"
 
 CONFIG_NOTOKEN = """
 [general]
@@ -83,6 +84,15 @@ def test_gitlab_merge_requests_closed():
     stats = did.cli.main(option + INTERVAL)[0][0].stats[0].stats[5].stats
     assert any([
         "did.tester/test-project#001 - Update README.md" in str(stat)
+        for stat in stats])
+
+def test_gitlab_merge_requests_approved():
+    """ Closed merge approved """
+    did.base.Config(CONFIG)
+    option = "--gitlab-merge-requests-approved "
+    stats = did.cli.main(option + APPROVED_INTERVAL)[0][0].stats[0].stats[6].stats
+    assert any([
+        "did.tester/test-project#003 - Use a nice complete sentence for description" in str(stat)
         for stat in stats])
 
 def test_github_invalid_token():


### PR DESCRIPTION
Hello! I would like to propose a small enhancement for the GitLab plugin. I daily review the patches on GitLab and I would like to see it in my status report. The pull request adds a search for approved merge requests on GitLab.  
The output looks next:
```
* Merge requests approved on gitlab: 7
    * testing-farm/artemis#431 - Bumping mypy to newer version, 0.730
    * testing-farm/artemis#429 - Replace uses of `Query` with `SafeQuery` in...
    * testing-farm/artemis#428 - Converts resource IDs container used by...
    * testing-farm/artemis#427 - Adds task to run post-install script when...
    * testing-farm/artemis#426 - Adds helpers for work with remote content...
    * testing-farm/artemis#395 - Changes return value of `drivers...
    * testing-farm/artemis#425 - Moves context code into a separate module
```
I have tested it in a virtual environment on my laptop manually. I have failed to run pytest, because IIUIC did.tester user hasn't done such action in the past. Could you suggest to me how can I work around this? I have an idea to mock the `search` function somehow so it will return some dummy data, but it seems not consistent in comparison to other tests to me.