### PR TITLE
Switch from fiscal year to natural year

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -227,7 +227,7 @@ Evgeni Golov, Stanislav Ochotnický, Maroš Kopec, Robbie Harwood,
 Christopher Sams, Thomas Heute, Giulio Fidente, Han Han, Qiao
 Zhao, Henrique Ferreiro, Jakub Vávra, Luigi Toscano, Lukáš
 Zapletal, Maryna Nalbandian, Dominika Hoďovská, Jakub Haruda,
-Han Han, Štěpán Němec and Evgeny Fedin.
+Han Han, Štěpán Němec, Evgeny Fedin and Mikel Olasagasti Uranga.
 
 
 Copyright

--- a/did/base.py
+++ b/did/base.py
@@ -281,7 +281,7 @@ class Date(object):
 
     @staticmethod
     def this_year():
-        """ Return start and end date of this natural year """
+        """ Return start and end date of this year """
         since = TODAY
         while since.month != 1 or since.day != 1:
             since -= delta(days=1)
@@ -290,7 +290,7 @@ class Date(object):
 
     @staticmethod
     def last_year():
-        """ Return start and end date of the last natural year """
+        """ Return start and end date of the last year """
         since, until = Date.this_year()
         since = since.date - delta(years=1)
         until = until.date - delta(years=1)
@@ -320,10 +320,10 @@ class Date(object):
         elif "year" in argument:
             if "last" in argument:
                 since, until = Date.last_year()
-                period = "the last natural year"
+                period = "the last year"
             else:
                 since, until = Date.this_year()
-                period = "this natural year"
+                period = "this year"
         elif "quarter" in argument:
             if "last" in argument:
                 since, until = Date.last_quarter()

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -97,13 +97,13 @@ def test_Date_period():
         since, until, period = Date.period(argument)
         assert str(since) == "2015-01-01"
         assert str(until) == "2016-01-01"
-        assert period == "this natural year"
+        assert period == "this year"
     # Last year
     for argument in ["last year"]:
         since, until, period = Date.period(argument)
         assert str(since) == "2014-01-01"
         assert str(until) == "2015-01-01"
-        assert period == "the last natural year"
+        assert period == "the last year"
     # Adding and subtracting days
     assert str(Date('2018-11-29') + 1) == '2018-11-30'
     assert str(Date('2018-11-29') + 2) == '2018-12-01'


### PR DESCRIPTION
Rather than a natural year, operands for years were using March as start date.
I think this is related to when Red Hat was an independent company and the
fiscal year used to start in March. Now that Red Hat alings with IBM's fiscal
year I think it's not needed anymore.