### PR TITLE
Use user email for searching updated jira issues

### DIFF
--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -181,7 +181,7 @@ class JiraUpdated(Stats):
             query = (
                 "issueFunction in commented"
                 "('by {0} after {1} before {2}')".format(
-                    self.parent.login or self.user.login,
+                    self.parent.login or self.user.email,
                     self.options.since, self.options.until))
             if self.parent.project:
                 query = query + " AND project = '{0}'".format(


### PR DESCRIPTION
The Jira issues are found when the python searches use user.email instead of user.login.