### PR TITLE
Return all the bugzilla results from a search

### DIFF
--- a/did/plugins/bugzilla.py
+++ b/did/plugins/bugzilla.py
@@ -79,6 +79,7 @@ class Bugzilla(object):
     def search(self, query, options):
         """ Perform Bugzilla search """
         query["query_format"] = "advanced"
+        query["limit"] = "0"
         log.debug("Search query:")
         log.debug(pretty(query))
         # Fetch bug info


### PR DESCRIPTION
As of 2021-09-13, bugzilla.redhat.com only returns 20 results (by
default) from a search.  The limit parameter can override this (up to
1000 results).  A limit of 0 is the same as max, so use 0 in did.

https://bugzilla.redhat.com/docs/en/html/integrating/api/Bugzilla/WebService/Bug.html?highlight=limit#search

Resolves issue #254 