### PR TITLE
Add minor clarification note about token name

### DIFF
--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -26,7 +26,8 @@ token_expiration
     specified number of ``days``.
 
 token_name
-    Name of the token to check for expiration in ``token_expiration`` days.
+    Name of the token to check for expiration in ``token_expiration``
+    days. This has to match the name as seen in your Jira profile.
 
 Configuration example (GSS authentication)::
 


### PR DESCRIPTION
I did not get at the first time that the name is the actual token name,
not just some local alias.

On the second thought, it seems kina obvious, but perhaps the note might
still help someone.