### PR TITLE
handle GitHub API rate limit

### DIFF
--- a/did/plugins/github.py
+++ b/did/plugins/github.py
@@ -78,6 +78,12 @@ class GitHub(object):
             try:
                 data = json.loads(response.text)["items"]
                 result.extend(data)
+            except KeyError:
+                if json.loads(response.text)["message"].startswith(
+                        "API rate limit exceeded"):
+                    raise ReportError(
+                        "GitHub API rate limit exceeded. "
+                        "Consider creating an access token.")
             except requests.exceptions.JSONDecodeError as error:
                 log.debug(error)
                 raise ReportError(f"GitHub JSON failed: {response.text}.")


### PR DESCRIPTION
GitHub API has serious rate limit for tokenless queries.

So instead of failing with traceback just print info that GitHub API
rate limit was exceeded.