### PR TITLE
feat: token_file config support for github plugin

### DIFF
--- a/did/plugins/github.py
+++ b/did/plugins/github.py
@@ -15,12 +15,16 @@ queries are limited. For more details see `GitHub API`__ docs.
 Use ``login`` to override the default email address for searching.
 See the :doc:`config` documentation for details on using aliases.
 
+Alternatively to `token` you can use `token_file` to have the
+token stored in a file rather than in your did config file.
+
 __ https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 
 """
 
 import json
 import re
+import os
 
 import requests
 
@@ -209,9 +213,13 @@ class GitHubStats(StatsGroup):
             raise ReportError(
                 "No github url set in the [{0}] section".format(option))
         # Check authorization token
-        try:
+        if "token" in config:
             self.token = config["token"]
-        except KeyError:
+        elif "token_file" in config:
+            file_path = os.path.expanduser(config["token_file"])
+            with open(file_path) as token_file:
+                self.token = token_file.read().strip()
+        else:
             self.token = None
         self.github = GitHub(self.url, self.token)
         # Create the list of stats

--- a/tests/plugins/test_github.py
+++ b/tests/plugins/test_github.py
@@ -1,7 +1,9 @@
 # coding: utf-8
 """ Tests for the GitHub plugin """
 
+import os
 import time
+from tempfile import NamedTemporaryFile
 
 import pytest
 
@@ -113,3 +115,18 @@ def test_github_unicode():
     assert any([
         "Boundary events lose it’s documentation" in str(stat)
         for stat in stats])
+
+
+@pytest.mark.skipif("GITHUB_TOKEN" not in os.environ, reason="No GITHUB_TOKEN environment variable found")
+def test_github_issues_created_with_token_file():
+    """ Created issues (config with token_file)"""
+    token = os.getenv(key="GITHUB_TOKEN")
+    file_handle = NamedTemporaryFile(mode="w+", encoding="utf-8")
+    file_handle.writelines(token)
+    file_handle.flush()
+    config = CONFIG + f"\ntoken_file = {file_handle.name}"
+    did.base.Config(config)
+    option = "--gh-issues-created "
+    stats = did.cli.main(option + INTERVAL)[0][0].stats[0].stats[0].stats
+    assert any([
+        "psss/did#017 - What did you do" in str(stat) for stat in stats])


### PR DESCRIPTION
This adds the possibility to not only use the `token_file` setting with
the github plugin. The overall goal is to make did-config files more
sharable and when you have the `token` visible within your config, this
is potentially more dangerous.
