### PR TITLE
Allow all plugins to fetch secrets from files

### DIFF
--- a/did/base.py
+++ b/did/base.py
@@ -457,3 +457,45 @@ class User(object):
         if login is not None:
             self.login = login
             log.info("Using login alias '{0}' for '{1}'".format(login, stats))
+
+
+def get_token(
+        config: dict,
+        token_key: str = "token",
+        token_file_key: str = "token_file") -> str:
+    """
+    Extract the authentication token from config or token file
+
+    Returns the contents of `config[token_key]`, or the file contents of
+    `config[token_file_key]` if no `config[token]` exists. If neither
+    keys exist, `None` is returned.
+
+    Sometimes you want to be able to store a token in a file rather than
+    in the your plain config file. Use this function to support a system
+    wide mechanism to retrieve tokens or secrets either directly from
+    the config file as plain text or from an outsourced file.
+
+    Returns:
+        str: The stripped token or `None` if no or only empty entries were
+            found in the `config` dict.
+
+    Keyword Args:
+        config (dict): A configuration dictionary
+        token_key (str): The dict entry to look for when the token is stored
+            as plain text in the config
+        token_file_key (str): The dict entry to look for when the token is
+            supposed to be read from file
+    """
+    token = None
+
+    if token_key in config:
+        token = str(config[token_key]).strip()
+    elif token_file_key in config:
+        file_path = os.path.expanduser(config[token_file_key])
+        with open(file_path, encoding="utf-8") as token_file:
+            token = token_file.read().strip()
+
+    if token == "":
+        token = None
+
+    return token

--- a/did/plugins/github.py
+++ b/did/plugins/github.py
@@ -15,6 +15,9 @@ queries are limited. For more details see `GitHub API`__ docs.
 Use ``login`` to override the default email address for searching.
 See the :doc:`config` documentation for details on using aliases.
 
+Alternatively to ``token`` you can use ``token_file`` to have the
+token stored in a file rather than in your did config file.
+
 __ https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
 
 """
@@ -24,7 +27,7 @@ import re
 
 import requests
 
-from did.base import Config, ReportError
+from did.base import Config, ReportError, get_token
 from did.stats import Stats, StatsGroup
 from did.utils import listed, log, pretty
 
@@ -209,10 +212,7 @@ class GitHubStats(StatsGroup):
             raise ReportError(
                 "No github url set in the [{0}] section".format(option))
         # Check authorization token
-        try:
-            self.token = config["token"]
-        except KeyError:
-            self.token = None
+        self.token = get_token(config)
         self.github = GitHub(self.url, self.token)
         # Create the list of stats
         self.stats = [

--- a/did/plugins/gitlab.py
+++ b/did/plugins/gitlab.py
@@ -8,6 +8,7 @@ Config example::
     type = gitlab
     url = https://gitlab.com/
     token = <authentication-token>
+    token_file = <authentication-token-file>
     login = <username>
     ssl_verify = true
 
@@ -29,7 +30,7 @@ import dateutil
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
-from did.base import Config, ReportError
+from did.base import Config, ReportError, get_token
 from did.stats import Stats, StatsGroup
 from did.utils import listed, log, pretty
 
@@ -326,9 +327,8 @@ class GitLabStats(StatsGroup):
             raise ReportError(
                 "No GitLab url set in the [{0}] section".format(option))
         # Check authorization token
-        try:
-            self.token = config["token"]
-        except KeyError:
+        self.token = get_token(config)
+        if self.token is None:
             raise ReportError(
                 "No GitLab token set in the [{0}] section".format(option))
         # Check SSL verification

--- a/did/plugins/google.py
+++ b/did/plugins/google.py
@@ -42,6 +42,10 @@ During the first run, user will be asked to grant the plugin access rights to
 selected apps. If the user approves the request, this decision is remembered by
 creating a *credential storage* file. The path to the storage can be customized
 by configuring the ``storage`` option.
+
+If you want to store the ``client_id`` and ``client_secret`` not as plain text
+within your config file, use ``client_id_file`` and ``client_secret_file`` to
+point to files with the corresponding files.
 """
 
 import os
@@ -52,7 +56,7 @@ from oauth2client import tools
 from oauth2client.client import OAuth2WebServerFlow
 from oauth2client.file import Storage
 
-from did.base import CONFIG, Config, ReportError
+from did.base import CONFIG, Config, get_token
 from did.stats import Stats, StatsGroup
 from did.utils import log, split
 
@@ -278,8 +282,12 @@ class GoogleStatsGroup(StatsGroup):
     def __init__(self, option, name=None, parent=None, user=None):
         super(GoogleStatsGroup, self).__init__(option, name, parent, user)
         config = dict(Config().section(option))
-        client_id = config["client_id"]
-        client_secret = config["client_secret"]
+        client_id = get_token(
+            config, token_key="client_id", token_file_key="client_id_file")
+        client_secret = get_token(
+            config,
+            token_key="client_secret",
+            token_file_key="client_secret_file")
         storage = config.get("storage")
         if storage is not None:
             storage = os.path.expanduser(storage)

--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -88,7 +88,7 @@ import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from requests_gssapi import DISABLED, HTTPSPNEGOAuth
 
-from did.base import Config, ReportError
+from did.base import Config, ReportError, get_token
 from did.stats import Stats, StatsGroup
 from did.utils import listed, log, pretty
 
@@ -301,13 +301,8 @@ class JiraStats(StatsGroup):
                     "in the [{0}] section.".format(option))
         # Token
         elif self.auth_type == "token":
-            if "token" in config:
-                self.token = config["token"]
-            elif "token_file" in config:
-                file_path = os.path.expanduser(config["token_file"])
-                with open(file_path) as token_file:
-                    self.token = token_file.read().strip()
-            else:
+            self.token = get_token(config)
+            if self.token is None:
                 raise ReportError(
                     "The `token` or `token_file` key must be set "
                     "in the [{0}] section.".format(option))

--- a/did/plugins/pagure.py
+++ b/did/plugins/pagure.py
@@ -12,14 +12,15 @@ Config example::
 
 Use ``login`` to override the default email address for searching.
 See the :doc:`config` documentation for details on using aliases.
-The authentication token is optional.
+The authentication token is optional and can be stored in a file
+pointed to by ``token_file`` instead of ``token``.
 """
 
 import datetime
 
 import requests
 
-from did.base import Config, ReportError
+from did.base import Config, ReportError, get_token
 from did.stats import Stats, StatsGroup
 from did.utils import listed, log, pretty
 
@@ -175,10 +176,7 @@ class PagureStats(StatsGroup):
             raise ReportError(
                 'No Pagure url set in the [{0}] section'.format(option))
         # Check authorization token
-        try:
-            self.token = config['token']
-        except KeyError:
-            self.token = None
+        self.token = get_token(config)
         self.pagure = Pagure(self.url, self.token)
         # Create the list of stats
         self.stats = [

--- a/did/plugins/sentry.py
+++ b/did/plugins/sentry.py
@@ -10,8 +10,10 @@ Configuration example::
     organization = team
     token = ...
 
-You need to generate authentication token at the server.
-The only scope you need to enable is `org:read`.
+You need to generate authentication token at the server. The only
+scope you need to enable is `org:read`. If you prefer to store the
+token in a file, use ``token_file`` to point to the file that has
+your token.
 """
 
 import re
@@ -19,7 +21,7 @@ import re
 import dateutil
 import requests
 
-from did.base import Config, ConfigError, ReportError
+from did.base import Config, ConfigError, ReportError, get_token
 from did.stats import Stats, StatsGroup
 from did.utils import listed, log, pretty
 
@@ -162,10 +164,13 @@ class SentryStats(StatsGroup):
         StatsGroup.__init__(self, option, name, parent, user)
         # Check config for required fields
         config = dict(Config().section(option))
-        for field in ['url', 'organization', 'token']:
+        for field in ['url', 'organization']:
             if field not in config:
-                raise ConfigError(
-                    "No {0} set in the [{1}] section".format(field, option))
+                raise ConfigError(f"No {field} set in the [{option}] section")
+        config["token"] = get_token(config)
+        if config["token"] is None:
+            raise ConfigError(
+                f"No token or token_file set in the [{option}] section")
         # Set up the Sentry API and construct the list of stats
         self.sentry = Sentry(config=config, stats=self)
         self.stats = [

--- a/did/plugins/trello.py
+++ b/did/plugins/trello.py
@@ -22,17 +22,20 @@ Optional arguments::
         updateCard:idList, updateCard:closed,
         updateCheckItemStateOnCard
 
-apikey
-    https://trello.com/app-key
+    apikey
+        https://trello.com/app-key
 
-token
-    http://stackoverflow.com/questions/17178907
+    token
+        http://stackoverflow.com/questions/17178907
 
-boards
-    default: all
+    token_file
+        the token stored in a file
 
-filters
-    default: all
+    boards
+        default: all
+
+    filters
+        default: all
 """
 
 # Possible API methods to add:
@@ -42,7 +45,7 @@ import json
 import urllib.parse
 import urllib.request
 
-from did.base import Config, ReportError
+from did.base import Config, ReportError, get_token
 from did.stats import Stats, StatsGroup
 from did.utils import listed, log, pretty, split
 
@@ -282,6 +285,7 @@ class TrelloStatsGroup(StatsGroup):
         self.url = "https://trello.com/1"
         config = dict(Config().section(option))
 
+        config["token"] = get_token(config)
         positional_args = ['apikey', 'token']
         if (not set(positional_args).issubset(set(config.keys()))
                 and "user" not in config):
@@ -289,7 +293,7 @@ class TrelloStatsGroup(StatsGroup):
                 "No ({0}) or 'user' set in the [{1}] section".format(
                     listed(positional_args, quote="'"), option))
 
-        optional_args = ["board_links", "apikey", "token"]
+        optional_args = ["board_links", "apikey"]
         for arg in optional_args:
             if arg not in config:
                 config[arg] = ""

--- a/did/plugins/zammad.py
+++ b/did/plugins/zammad.py
@@ -9,6 +9,9 @@ Config example::
     url = https://zammad.example.com/api/v1/
     token = <authentication-token>
 
+Optionally use ``token_file`` to store the token in a file instead
+of plain in the config file.
+
 """
 
 import json
@@ -16,7 +19,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-from did.base import Config, ReportError
+from did.base import Config, ReportError, get_token
 from did.stats import Stats, StatsGroup
 from did.utils import listed, log, pretty
 
@@ -119,10 +122,7 @@ class ZammadStats(StatsGroup):
             raise ReportError(
                 "No zammad url set in the [{0}] section".format(option))
         # Check authorization token
-        try:
-            self.token = config["token"]
-        except KeyError:
-            self.token = None
+        self.token = get_token(config)
         self.zammad = Zammad(self.url, self.token)
         # Create the list of stats
         self.stats = [

--- a/tests/plugins/test_github.py
+++ b/tests/plugins/test_github.py
@@ -1,7 +1,9 @@
 # coding: utf-8
 """ Tests for the GitHub plugin """
 
+import os
 import time
+from tempfile import NamedTemporaryFile
 
 import pytest
 
@@ -113,3 +115,19 @@ def test_github_unicode():
     assert any([
         "Boundary events lose it’s documentation" in str(stat)
         for stat in stats])
+
+
+@pytest.mark.skipif("GITHUB_TOKEN" not in os.environ,
+                    reason="No GITHUB_TOKEN environment variable found")
+def test_github_issues_created_with_token_file():
+    """ Created issues (config with token_file)"""
+    token = os.getenv(key="GITHUB_TOKEN")
+    with NamedTemporaryFile(mode="w+", encoding="utf-8") as file_handle:
+        file_handle.writelines(token)
+        file_handle.flush()
+        config = CONFIG + f"\ntoken_file = {file_handle.name}"
+        did.base.Config(config)
+        option = "--gh-issues-created "
+        stats = did.cli.main(option + INTERVAL)[0][0].stats[0].stats[0].stats
+        assert any([
+            "psss/did#017 - What did you do" in str(stat) for stat in stats])


### PR DESCRIPTION
Some plugins like the Jira one allowed to store their token used for
authentication within a file and have you point to the file using the
`token_file` config option. I liked that idea because it makes did
config files much more shareable amongst team members.

That's why I've added the token-in-file mechanism to all plugins. The
google plugin also stores a `client_it` and `client_secret` that you can
also put into a file now by specifying `client_id_file` and
`client_secret_file`.

I've added tests for the `get_token` function and for the github plugin
to utilize this function when running in a Github action because then
the environment variable `GITHUB_TOKEN` is set and can be tested when
putting it in a token file only for it to be consumed then.
