### PR TITLE
Fix error when building SRPM in copr

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,6 +4,9 @@ actions:
   get-current-version:
   - make version
 
+srpm_build_deps:
+  - make
+
 jobs:
 - job: tests
   trigger: pull_request


### PR DESCRIPTION
This PR should fix this error:

```
packit.exceptions.PackitSRPMException: Preparation of the repository for creation of an SRPM failed: [Errno 2] No such file or directory: 'make'
```

Read more about the change here and why it only is required since January 2023: https://packit.dev/docs/configuration/#srpm_build_deps