### PR TITLE
Add "name-tests-test" pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,7 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+      - id: name-tests-test
+        args:
+          - --pytest-test-first
+        exclude: disable_test_trac.py


### PR DESCRIPTION
The `name-tests-test` hook verifies that test files are named "correctly". That's why all test files have to start with `test_*.py`.

See https://pre-commit.com/hooks.html