### PR TITLE
Fix broken phabricator tests

### DIFF
--- a/tests/plugins/test_phabricator.py
+++ b/tests/plugins/test_phabricator.py
@@ -25,7 +25,7 @@ type = phabricator
 
 URL = "url = https://reviews.llvm.org/api/"
 LOGINS = "login = kwk, kkleine"
-TOKEN = 'token = {os.getenv(key="PHABRICATOR_TOKEN", default="No token specified")}'
+TOKEN = "token = " + os.getenv(key="PHABRICATOR_TOKEN", default="NoTokenSpecified")
 
 CONFIG_OK = f"""
 {CONFIG_BASE}
@@ -50,7 +50,6 @@ CONFIG_BAD_MISSING_TOKEN = f"""
 {CONFIG_BASE}
 {URL}
 {LOGINS}
-{TOKEN}
 """
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -94,7 +93,7 @@ def test_differentials_created():
     needle = "D129553 [standalone-build-x86_64]: build lld"
     assert any([needle in str(stat) for stat in stats])
     # Verbose search (URL is prefixed instead of differential number)
-    option = "--ph-differentials-created --verbose"
+    option = "--ph-differentials-created --verbose "
     stats = did.cli.main(option + INTERVAL)[0][0].stats[0].stats[0].stats
     needle = "https://reviews.llvm.org/D129553 [standalone-build-x86_64]: build lld"
     assert any([needle in str(stat) for stat in stats])
@@ -111,7 +110,7 @@ def test_differentials_reviewed():
     needle = "D99780 workflows: Add GitHub action for automating some release tasks"
     assert any([needle in str(stat) for stat in stats])
     # Verbose search (URL is prefixed instead of differential number)
-    option = "--ph-differentials-reviewed --verbose"
+    option = "--ph-differentials-reviewed --verbose "
     stats = did.cli.main(option + INTERVAL)[0][0].stats[0].stats[1].stats
     needle = "https://reviews.llvm.org/D99780 workflows: Add GitHub action "\
              "for automating some release tasks"


### PR DESCRIPTION
Fixes:

* I've wrongly used format strings before.
* Also, this test fixed the `did.base.OptionError: Invalid argument: '--verbose--since'` error that was showing without the additional spaces added by this patch.
* Fix `test_missing_token`: The `CONFIG_BAD_MISSING_TOKEN` string was identical to the `CONFIG_OK` string and thus didn't raise `ConfigError` as expected when the token part is missing. 