### PR TITLE
Address packit warning on `metadata` key

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,22 +19,20 @@ jobs:
 
 - job: tests
   trigger: pull_request
-  metadata:
-    targets:
-    - fedora-all
-    - epel-8
-    - epel-9
+  targets:
+  - fedora-all
+  - epel-8
+  - epel-9
 
 - job: copr_build
   trigger: commit
-  metadata:
-    branch: main
-    targets:
-    - fedora-all
-    - epel-8
-    - epel-9
-    enable_net: False
-    list_on_homepage: True
-    preserve_project: True
-    owner: psss
-    project: did
+  branch: main
+  targets:
+  - fedora-all
+  - epel-8
+  - epel-9
+  enable_net: False
+  list_on_homepage: True
+  preserve_project: True
+  owner: psss
+  project: did


### PR DESCRIPTION
To see the warning, go to an SRPM build log and search for this text:

```
WARNING The 'metadata' key in jobs is deprecated and can be removed. Nest config options from 'metadata' directly under the job object.
```

To reproduce the problem locally, use `packit srpm`.
