### PR TITLE
Release did-0.20

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -228,7 +228,8 @@ Christopher Sams, Thomas Heute, Giulio Fidente, Han Han, Qiao
 Zhao, Henrique Ferreiro, Jakub Vávra, Luigi Toscano, Lukáš
 Zapletal, Maryna Nalbandian, Dominika Hoďovská, Jakub Haruda,
 Han Han, Štěpán Němec, Evgeny Fedin, Mikel Olasagasti Uranga,
-Miloš Malík, Jeffrey Bastian, Côme Chilliet and Konrad Kleine.
+Miloš Malík, Jeffrey Bastian, Côme Chilliet, Marcin Juszkiewicz,
+Tomáš Kopeček, Konrad Kleine, Sandro Bonazzola and Morgan Weetman.
 
 
 Copyright

--- a/did.spec
+++ b/did.spec
@@ -1,5 +1,5 @@
 Name: did
-Version: 0.19
+Version: 0.20
 Release: 1%{?dist}
 
 Summary: What did you do last week, month, year?
@@ -54,6 +54,30 @@ export LANG=en_US.utf-8
 %license LICENSE
 
 %changelog
+* Thu Mar 09 2023 Petr Šplíchal <psplicha@redhat.com> - 0.20-1
+- Produce fixed `phabricator` statistics
+- Address packit warning on the `metadata` key
+- Remove the Travis CI configuration
+- Fix pytest invocation
+- Move common constants to the top of `did.utils`
+- Add new configuration options for custom separator
+- Fix broken phabricator tests
+- Fix potentially uninitialized local variable
+- Add CodeQL workflow for GitHub code scanning
+- Add comment stats on GitHub issues & pull requests
+- Add the `name-tests-test` pre-commit hook
+- Add the new `phabricator` plugin
+- Update test data for `sentry`, `gitlab` and `gerrit`
+- Update `pre-commit` configuration, enable `flake8`
+- Allow all plugins to fetch secrets from files
+- Update packit config to address recent changes
+- Fix typo in the Google plugin docstring
+- Speed up local testing, add missing require
+- Update google plugin installation instructions
+- Koji plugin
+- Handle GitHub API rate limit
+- Add Github Action for PyPI releases
+
 * Tue Jan 18 2022 Lukáš Zachar <lzachar@redhat.com> - 0.19-1
 - Install all required packages during docs building
 - Adjust code style to be pep8 compatible


### PR DESCRIPTION
- Produce fixed `phabricator` statistics
- Address packit warning on the `metadata` key
- Remove the Travis CI configuration
- Fix pytest invocation
- Move common constants to the top of `did.utils`
- Add new configuration options for custom separator
- Fix broken phabricator tests
- Fix potentially uninitialized local variable
- Add CodeQL workflow for GitHub code scanning
- Add comment stats on GitHub issues & pull requests
- Add the `name-tests-test` pre-commit hook
- Add the new `phabricator` plugin
- Update test data for `sentry`, `gitlab` and `gerrit`
- Update `pre-commit` configuration, enable `flake8`
- Allow all plugins to fetch secrets from files
- Update packit config to address recent changes
- Fix typo in the Google plugin docstring
- Speed up local testing, add missing require
- Update google plugin installation instructions
- Koji plugin
- Handle GitHub API rate limit
- Add Github Action for PyPI releases
