### PR TITLE
Skip own pull requests in `pull-requests-reviewed`

### DIFF
--- a/did/plugins/github.py
+++ b/did/plugins/github.py
@@ -211,7 +211,7 @@ class PullRequestsReviewed(Stats):
     def fetch(self):
         log.info("Searching for pull requests reviewed by {0}".format(
             self.user))
-        query = "search/issues?q=reviewed-by:{0}+closed:{1}..{2}".format(
+        query = "search/issues?q=reviewed-by:{0}+-author:{0}+closed:{1}..{2}".format(
             self.user.login, self.options.since, self.options.until)
         query += "+type:pr"
         self.stats = [


### PR DESCRIPTION
For some reason the GitHub query for reviewed pull requests includes some created pull requests as well. Although the issue has been filed in 2019 it still has not been addressed on their side. Let's explicitly omit pull requests created by the reviewer to workaround this.