### PR TITLE
Support defining subitems for header and footer

### DIFF
--- a/did/plugins/footer.py
+++ b/did/plugins/footer.py
@@ -9,6 +9,20 @@ Config example::
     type = footer
     next = Plans, thoughts, ideas...
     status = Status: Green | Yellow | Orange | Red
+
+New line characters can be used in the definition as well. In this way
+it's possible to define subitems::
+
+    [footer]
+    type = footer
+    nested = Main topic\\n  * Item one\\n  * Item two\\n  * Item three
+
+Will produce the following output::
+
+    * Main topic
+      * Item one
+      * Item two
+      * Item three
 """
 
 from did.stats import EmptyStatsGroup

--- a/did/plugins/header.py
+++ b/did/plugins/header.py
@@ -8,6 +8,20 @@ Config example::
     type = header
     highlights = Highlights
     joy = Joy of the week ;-)
+
+New line characters can be used in the definition as well. In this way
+it's possible to define subitems::
+
+    [header]
+    type = header
+    nested = Main topic\\n  * Item one\\n  * Item two\\n  * Item three
+
+Will produce the following output::
+
+    * Main topic
+      * Item one
+      * Item two
+      * Item three
 """
 
 from did.stats import EmptyStatsGroup

--- a/did/stats.py
+++ b/did/stats.py
@@ -2,6 +2,7 @@
 
 """ Stats & StatsGroup, the core of the data gathering """
 
+import re
 import xmlrpc.client
 
 import did.base
@@ -253,7 +254,10 @@ class EmptyStats(Stats):
 
     def show(self):
         """ Name only for empty stats """
-        utils.item(self.name, options=self.options)
+        # Convert escaped new lines into real new lines
+        # (in order to support custom subitems for each item)
+        item = re.sub(r"\\n", "\n", self.name)
+        utils.item(item, options=self.options)
 
     def fetch(self):
         """ Nothing to do for empty stats """


### PR DESCRIPTION
Convert escaped new lines into real new lines to allow printing custom subitems in header and footer.

Fix #268.