### PR TITLE
Update pre-commit GitHub action with the latest version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Solves:

>  The following actions uses node12 which is deprecated and will be forced
>  to run on node16: actions/checkout@v2, actions/setup-python@v2,
>  pre-commit/action@v2.0.2.
>  For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
