### PR TITLE
Move line length recommendation to proper section

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -18,6 +18,7 @@ Our favorite thoughts from The Zen of Python:
 We respect the `PEP8`__ Style Guide for Python Code. Here's a
 couple of recommendations to keep on mind when writing code:
 
+* Maximum line length is 88 for code and 72 for docs.
 * Comments should be complete sentences.
 * The first word should be capitalized (unless identifier).
 * When using hanging indent, the first line should be empty.
@@ -35,7 +36,6 @@ It is challenging to be both concise and descriptive, but that is
 what a well-written summary should do. Consider the commit message
 as something that will be pasted into release notes:
 
-* Maximum line length is 88 for code and 72 for docs.
 * The first line should have up to 50 characters.
 * Complete sentence with the first word capitalized.
 * Should concisely describe the purpose of the patch.


### PR DESCRIPTION
It somehow landed under the commit section but belongs to the introduction paragraph.