### PR TITLE
Fix docs building warnings, pin sphinx version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,11 @@ python:
       - method: pip
         path: .
         extra_requirements: [all]
+
 build:
+    os: ubuntu-22.04
+    tools:
+        python: "3.11"
     apt_packages:
       - python3-dev
       - libkrb5-dev

--- a/did/base.py
+++ b/did/base.py
@@ -491,16 +491,18 @@ def get_token(
     wide mechanism to retrieve tokens or secrets either directly from
     the config file as plain text or from an outsourced file.
 
-    Returns:
-        str: The stripped token or `None` if no or only empty entries
-            were found in the `config` dict.
+    :param config:
+        A configuration dictionary.
+    :param token_key:
+        The dict entry to look for when the token is stored as plain
+        text in the config.
+    :param token_file_key:
+        The dict entry to look for when the token is supposed to be read
+        from file.
+    :returns:
+        The stripped token or `None` if no or only empty entries were
+        found in the `config` dict.
 
-    Keyword Args:
-        config (dict): A configuration dictionary
-        token_key (str): The dict entry to look for when the token is
-            stored as plain text in the config
-        token_file_key (str): The dict entry to look for when the token
-            is supposed to be read from file
     """
     token = None
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ release = ''
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,0 @@
-google-api-python-client
-oauth2client
-mock

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
 extras_require = {
     'bodhi': ['bodhi-client'],
     'bugzilla': ['python-bugzilla'],
-    'docs': ['sphinx>3', 'mock', 'sphinx_rtd_theme'],
+    'docs': ['sphinx==7.2.4', 'sphinx-rtd-theme==1.3.0'],
     'google': ['google-api-python-client', 'oauth2client'],
     'jira': ['requests_gssapi'],
     'koji': ['koji'],


### PR DESCRIPTION
Fix several warnings raised during the docs building. Pin exact `sphinx` version to prevent import failures.