### PR TITLE
Replace deprecated calls to `warn`

### DIFF
--- a/did/plugins/git.py
+++ b/did/plugins/git.py
@@ -78,7 +78,7 @@ class GitRepo(object):
                 return commits
         else:
             log.debug(errors.strip())
-            log.warn("Unable to check commits in '{0}'".format(self.path))
+            log.warning("Unable to check commits in '{0}'".format(self.path))
             return []
 
 

--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -432,10 +432,10 @@ class JiraStats(StatsGroup):
                     delta = (
                         expiring_at.astimezone() - datetime.now().astimezone())
                     if delta.days < self.token_expiration:
-                        log.warn(
+                        log.warning(
                             f"Jira token '{self.token_name}' "
                             f"expires in {delta.days} days.")
                 except (requests.exceptions.HTTPError,
                         KeyError, ValueError) as error:
-                    log.warn(error)
+                    log.warning(error)
         return self._session

--- a/did/stats.py
+++ b/did/stats.py
@@ -131,7 +131,7 @@ class StatsGroupPlugin(type):
 
         if plugin_name in registry:
             orig = registry[plugin_name]
-            log.warn("%s overriding %s" % (cls.__module__, orig.__module__))
+            log.warning("%s overriding %s" % (cls.__module__, orig.__module__))
 
         registry[plugin_name] = cls
 


### PR DESCRIPTION
Fixes:
```console
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

when running with
```bash
export PYTHONWARNINGS="always::DeprecationWarning"
```