### PR TITLE
Handle connection error fetching gitlab user

### DIFF
--- a/did/plugins/gitlab.py
+++ b/did/plugins/gitlab.py
@@ -94,7 +94,12 @@ class GitLab(object):
 
     def get_user(self, username):
         query = 'users?username={0}'.format(username)
-        result = self._get_gitlab_api_json(query)
+        try:
+            result = self._get_gitlab_api_json(query)
+        except requests.exceptions.JSONDecodeError as jde:
+            raise ReportError(
+                f"Unable to query user '{username}' on {self.url}."
+                ) from jde
         try:
             return result[0]
         except IndexError:


### PR DESCRIPTION
Handle more gracefully connection issues while looking up for a user on GitLab. Previously only a traceback was generated, now an application error is printed on the screen.
Observed during https://gitlab.gnome.org/ outage