### PR TITLE
Pass plugin configuration to koji `ClientSession`

### DIFF
--- a/did/plugins/koji.py
+++ b/did/plugins/koji.py
@@ -59,7 +59,7 @@ class KojiStats(StatsGroup):
         except KeyError:
             raise did.base.ReportError(
                 "No koji url set in the [{0}] section".format(option))
-        server = koji.ClientSession(url)
+        server = koji.ClientSession(url, opts=config)
         try:
             user = server.getUser(config['login'], strict=True)
         except KeyError:


### PR DESCRIPTION
pass plugin section configuration to `koji.ClientSession` as option, allowing to pass options like `no_ssl_verify = True` (useful for koji private instances running with self signed certificates).