### PR TITLE
Release did-0.21

### DIFF
--- a/did.spec
+++ b/did.spec
@@ -1,5 +1,5 @@
 Name: did
-Version: 0.20
+Version: 0.21
 Release: 1%{?dist}
 
 Summary: What did you do last week, month, year?
@@ -55,6 +55,26 @@ export LANG=en_US.utf-8
 %license LICENSE
 
 %changelog
+* Fri Nov 10 2023 Petr Šplíchal <psplicha@redhat.com> - 0.21-1
+- Pass plugin configuration to koji `ClientSession`
+- Add `markdown` format output to `bodhi` plugin
+- Add `markdown` format output to `pagure` plugin
+- Handle connection error fetching gitlab user
+- Update instructions for the `google` plugin
+- Add `sphinx_rtd_theme` to the list of extensions
+- Replace deprecated calls to `warn`
+- Fix docs building warnings, pin sphinx version
+- Add support for `markdown` format output (#315)
+- Move line length recommendation to proper section
+- Update pre-commit GH action with latest version
+- Add dependency on `python3-feedparser`
+- Replace `readfp()` with `read_file()`
+- Support defining subitems for header and footer
+- Give a reasonable error for unreachable wiki url
+- Report Gitlab tasks-commented properly
+- Fix typo in section name
+- Skip own pull requests in `pull-requests-reviewed`
+
 * Thu Mar 09 2023 Petr Šplíchal <psplicha@redhat.com> - 0.20-1
 - Produce fixed `phabricator` statistics
 - Address packit warning on the `metadata` key


### PR DESCRIPTION
* Pass plugin configuration to koji `ClientSession`
* Add `markdown` format output to `bodhi` plugin
* Add `markdown` format output to `pagure` plugin
* Handle connection error fetching gitlab user
* Update instructions for the `google` plugin
* Add `sphinx_rtd_theme` to the list of extensions
* Replace deprecated calls to `warn`
* Fix docs building warnings, pin sphinx version
* Add support for `markdown` format output (#315)
* Move line length recommendation to proper section
* Update pre-commit GH action with latest version
* Add dependency on `python3-feedparser`
* Replace `readfp()` with `read_file()`
* Support defining subitems for header and footer
* Give a reasonable error for unreachable wiki url
* Report Gitlab tasks-commented properly
* Fix typo in section name
* Skip own pull requests in `pull-requests-reviewed`