### PR TITLE
Replace deprecated configparser readfp method

### DIFF
--- a/did/base.py
+++ b/did/base.py
@@ -102,7 +102,7 @@ class Config(object):
         # Parse the config from file
         try:
             log.info("Inspecting config file '{0}'.".format(path))
-            self.parser.readfp(codecs.open(path, "r", "utf8"))
+            self.parser.read_file(codecs.open(path, "r", "utf8"))
         except IOError as error:
             log.debug(error)
             Config.parser = None


### PR DESCRIPTION
read_file is a replacement from python 3.2. In python 3.12 it was completely removed.