### PR TITLE
Prevent duplicates in github issue stats

### DIFF
--- a/did/plugins/github.py
+++ b/did/plugins/github.py
@@ -131,6 +131,19 @@ class Issue(object):
                 self.owner, self.project,
                 str(self.id).zfill(PADDING), self.data["title"])
 
+    def __eq__(self, other):
+        """ Equality comparison """
+        if isinstance(other, Issue):
+            return (
+                self.owner == other.owner
+                and self.project == other.project
+                and self.id == other.id)
+        return False
+
+    def __hash__(self):
+        """ Hash function """
+        return hash((self.owner, self.project, self.id))
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Stats


### PR DESCRIPTION
Fixes #346 by adding equals method to Issue class that uses org/repo/id as key