### PR TITLE
Update all linters to the latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: 'v2.0.1'
+    rev: 'v2.0.4'
     hooks:
       - id: autopep8
         args:
@@ -14,12 +14,12 @@ repos:
           - --max-line-length=88
 
   - repo: https://github.com/PyCQA/isort
-    rev: "5.12.0"
+    rev: "5.13.2"
     hooks:
       - id: isort
 
   - repo: https://github.com/pycqa/flake8
-    rev: "6.0.0"
+    rev: "6.1.0"
     hooks:
       - id: flake8
         args:
@@ -40,7 +40,7 @@ repos:
           )$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.4.0"
+    rev: "v4.5.0"
     hooks:
       - id: end-of-file-fixer
       - id: mixed-line-ending


### PR DESCRIPTION
Resolves a false positive `missing whitespace after ':'` error reported by `flake8` for colons in strings.