### PR TITLE
Remove confusing mention from the `google` plugin

### DIFF
--- a/did/plugins/google.py
+++ b/did/plugins/google.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 """
-Google stats such as attended events, completed tasks or sent emails
+Google stats such as attended events or completed tasks
 
 Config example::
 


### PR DESCRIPTION
Email stats are not supported yet, so let's not confuse users.