### PR TITLE
Implement `transition` stats for the `jira` plugin

### DIFF
--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -29,7 +29,7 @@ token_name
     Name of the token to check for expiration in ``token_expiration``
     days. This has to match the name as seen in your Jira profile.
 
-transition_to
+transition_status
     Name of the issue status we want to report transitions to.
     Defaults to ``Release Pending`` (marking "verified" issues).
 
@@ -413,10 +413,10 @@ class JiraTransition(Stats):
         log.info(
             "[%s] Searching for issues transitioned to '%s' by '%s'",
             self.option,
-            self.parent.transition_to,
+            self.parent.transition_status,
             self.user.login or self.user.email)
         query = (
-            f"status changed to '{self.parent.transition_to}' "
+            f"status changed to '{self.parent.transition_status}' "
             f"and status changed by '{self.user.login or self.user.email}' "
             f"after {self.options.since} before {self.options.until}"
             )
@@ -544,7 +544,7 @@ class JiraStats(StatsGroup):
         self.prefix = config["prefix"] if "prefix" in config else None
 
         # State transition to count
-        self.transition_to = config.get("transition_to", DEFAULT_TRANSITION_TO)
+        self.transition_status = config.get("transition_status", DEFAULT_TRANSITION_TO)
 
         # Create the list of stats
         self.stats = [

--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -29,6 +29,10 @@ token_name
     Name of the token to check for expiration in ``token_expiration``
     days. This has to match the name as seen in your Jira profile.
 
+transition_to
+    Name of the issue status we want to report transitions to.
+    Defaults to ``Release Pending`` (marking "verified" issues).
+
 Configuration example (GSS authentication)::
 
     [issues]
@@ -113,6 +117,10 @@ SSL_VERIFY = True
 
 # Default number of seconds waiting on Sentry before giving up
 TIMEOUT = 60
+
+# State we are interested in
+DEFAULT_TRANSITION_TO = "Release Pending"
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Issue Investigator
@@ -397,6 +405,28 @@ class JiraContributed(Stats):
         self.stats = Issue.search(query, stats=self, timeout=self.parent.timeout)
         log.info("[%s] done issues contributed to", self.option)
 
+
+class JiraTransition(Stats):
+    """ Issues transitioned to specified state """
+
+    def fetch(self):
+        log.info(
+            "[%s] Searching for issues transitioned to '%s' by '%s'",
+            self.option,
+            self.parent.transition_to,
+            self.user.login or self.user.email)
+        query = (
+            "status changed to '{0}' and status changed by '{1}' "
+            "after {2} before {3}".format(
+                self.parent.transition_to,
+                self.user.login or self.user.email,
+                self.options.since,
+                self.options.until))
+        if self.parent.project:
+            query = query + " AND project = '{0}'".format(
+                self.parent.project)
+        self.stats = Issue.search(query, stats=self)
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Stats Group
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -515,6 +545,10 @@ class JiraStats(StatsGroup):
 
         # Check for custom prefix
         self.prefix = config["prefix"] if "prefix" in config else None
+
+        # State transition to count
+        self.transition_to = config.get("transition_to", DEFAULT_TRANSITION_TO)
+
         # Create the list of stats
         self.stats = [
             JiraCreated(
@@ -535,6 +569,9 @@ class JiraStats(StatsGroup):
             JiraUpdated(
                 option=f"{option}-updated", parent=self,
                 name=f"Issues updated in {option}"),
+            JiraTransition(
+                option=option + "-transitioned", parent=self,
+                name="Issues transitioned in {0}".format(option)),
             ]
 
     def _basic_auth_session(self):

--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -416,15 +416,12 @@ class JiraTransition(Stats):
             self.parent.transition_to,
             self.user.login or self.user.email)
         query = (
-            "status changed to '{0}' and status changed by '{1}' "
-            "after {2} before {3}".format(
-                self.parent.transition_to,
-                self.user.login or self.user.email,
-                self.options.since,
-                self.options.until))
+            f"status changed to '{self.parent.transition_to}' "
+            f"and status changed by '{self.user.login or self.user.email}' "
+            f"after {self.options.since} before {self.options.until}"
+            )
         if self.parent.project:
-            query = query + " AND project = '{0}'".format(
-                self.parent.project)
+            query = query + f" AND project = '{self.parent.project}'"
         self.stats = Issue.search(query, stats=self)
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -571,7 +568,7 @@ class JiraStats(StatsGroup):
                 name=f"Issues updated in {option}"),
             JiraTransition(
                 option=option + "-transitioned", parent=self,
-                name="Issues transitioned in {0}".format(option)),
+                name=f"Issues transitioned in {option}"),
             ]
 
     def _basic_auth_session(self):


### PR DESCRIPTION
Should I make it more generic? As in 'JiraTransitioned' ? In theory one could have config with one project counting 'Release Pending' and another where 'Integration' is counted as the user's role is different

Config like
```
[jira-where-developer]
project = DEVEL
transition_state = 'Integration'

[jira-where-qe]
project = QE
transition_state = 'Release Pending'
```

Seems that states and workflows can be too different