### PR TITLE
fix dockerfile path, add git to container

### DIFF
--- a/examples/dockerfile
+++ b/examples/dockerfile
@@ -1,17 +1,18 @@
 FROM fedora
 MAINTAINER langdon <langdon@fedoraproject.org>
 RUN yum clean all && yum -y update
-RUN yum -y install python python-pip make gcc krb5-devel python-devel python-setuptools python-gssapi python-nitrate python-dateutil python-urllib-gssapi
+RUN yum -y install python python-pip make gcc krb5-devel python-devel python-setuptools python-gssapi python-nitrate python-dateutil python-urllib-gssapi git
 RUN yum clean all
 
 COPY . /opt/did
 WORKDIR /opt/did
-RUN python setup.py install
+RUN git config --global --add safe.directory '*' \
+ && python setup.py install \
+ && ln -s /did.conf /root/.did
 #RUN ln -s /user-home/.did /root/.did
-RUN ln -s /did.conf /root/.did
 
 VOLUME /did.conf
 
 LABEL RUN docker run --privileged --rm -it -v $(HOME)/.did:/did.conf $(USERNAME)/did
 
-ENTRYPOINT ["/usr/bin/did"]
+ENTRYPOINT ["/opt/did/bin/did"]


### PR DESCRIPTION
The path seems out of date. I'm not knowledgeable in setuptools (or python at all for that matter, I had already tried using `did` a while ago but I had enough of it after 5 minutes due to the usual virtualenv mess) so maybe it's supposed to actually install in `/usr/bin` but isn't.

I've also added `git` to make the extension work within docker. `safe.directory` set to `*` allows git to get the logs in directories in which the user is not an owner (likely the case for docker).

Side note: I also changed the docker run command I personally use. I don't think `--privileged` is actually needed. I haven't changed the docs in this PR, I don't know if there are use cases where it does make sense. For reference, this is what I use: I also added a new volume for the repository I want to track using git.

```
docker run --rm -it -v /home/howl/.config/did:/did.conf -v /home/howl/oc/gno:/gno howl/did
```

Suggestion: may be a good idea to use a custom entrypoint script that can parse `$1` values like `bash` / `sh` and execute the commands accordingly, useful when debugging the container itself. Personally I just switched back and forth from `ENTRYPOINT` to `CMD` so I could test it out doing `did bash`.