### PR TITLE
Drop usage of distutils

### DIFF
--- a/MIT_LICENSE
+++ b/MIT_LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.

--- a/did/plugins/confluence.py
+++ b/did/plugins/confluence.py
@@ -31,7 +31,6 @@ Notes:
   higher priority.
 """
 
-import distutils.util
 import os
 import re
 import urllib.parse
@@ -42,7 +41,7 @@ from requests_gssapi import DISABLED, HTTPSPNEGOAuth
 
 from did.base import Config, ReportError
 from did.stats import Stats, StatsGroup
-from did.utils import listed, log, pretty
+from did.utils import listed, log, pretty, strtobool
 
 # Maximum number of results fetched at once
 MAX_RESULTS = 100
@@ -213,7 +212,7 @@ class ConfluenceStats(StatsGroup):
         # SSL verification
         if "ssl_verify" in config:
             try:
-                self.ssl_verify = distutils.util.strtobool(
+                self.ssl_verify = strtobool(
                     config["ssl_verify"])
             except Exception as error:
                 raise ReportError(

--- a/did/plugins/gitlab.py
+++ b/did/plugins/gitlab.py
@@ -23,7 +23,6 @@ __ https://docs.gitlab.com/ce/api/
 
 """
 
-import distutils.util
 from time import sleep
 
 import dateutil
@@ -32,7 +31,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 from did.base import Config, ReportError, get_token
 from did.stats import Stats, StatsGroup
-from did.utils import listed, log, pretty
+from did.utils import listed, log, pretty, strtobool
 
 GITLAB_SSL_VERIFY = True
 GITLAB_API = 4
@@ -381,7 +380,7 @@ class GitLabStats(StatsGroup):
                 "No GitLab token set in the [{0}] section".format(option))
         # Check SSL verification
         try:
-            self.ssl_verify = bool(distutils.util.strtobool(
+            self.ssl_verify = bool(strtobool(
                 config["ssl_verify"]))
         except KeyError:
             self.ssl_verify = GITLAB_SSL_VERIFY

--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -77,7 +77,6 @@ Notes:
   Other values are ``basic`` and ``token``.
 """
 
-import distutils.util
 import os
 import re
 import urllib.parse
@@ -89,7 +88,7 @@ from requests_gssapi import DISABLED, HTTPSPNEGOAuth
 
 from did.base import Config, ReportError, get_token
 from did.stats import Stats, StatsGroup
-from did.utils import listed, log, pretty
+from did.utils import listed, log, pretty, strtobool
 
 # Maximum number of results fetched at once
 MAX_RESULTS = 1000
@@ -344,7 +343,7 @@ class JiraStats(StatsGroup):
         # SSL verification
         if "ssl_verify" in config:
             try:
-                self.ssl_verify = distutils.util.strtobool(
+                self.ssl_verify = strtobool(
                     config["ssl_verify"])
             except Exception as error:
                 raise ReportError(
@@ -355,7 +354,7 @@ class JiraStats(StatsGroup):
         # Make sure we have project set
         self.project = config.get("project", None)
         if "use_scriptrunner" in config:
-            self.use_scriptrunner = distutils.util.strtobool(
+            self.use_scriptrunner = strtobool(
                 config["use_scriptrunner"])
         else:
             self.use_scriptrunner = True

--- a/did/utils.py
+++ b/did/utils.py
@@ -185,6 +185,30 @@ def shorted(text, width=MAX_WIDTH):
     return "\n".join(lines)
 
 
+def strtobool(val):
+    """
+    Convert a string representation of truth to true (1) or false (0).
+    Reimplemented following instructions at
+    https://peps.python.org/pep-0632/#migration-advice
+    This is a copy of
+    https://github.com/pypa/distutils/blob/ee021a1c58b43607ccc75447159bd90f502c6bea/distutils/util.py#L340
+    Which is under MIT license.
+
+    Returns:
+      1 if val is within 'y', 'yes', 't', 'true', 'on', and '1'.
+      0 if val is within 'n', 'no', 'f', 'false', 'off', and '0'.
+    Raises:
+       ValueError if 'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value {!r}".format(val))
+
+
 def item(text, level=0, options=None):
     """ Print indented item. """
     # Extra line before in each section (unless brief)


### PR DESCRIPTION
Replace `distutils.util.strtobool` with a local copy of the function following the
[Migration advice](https://peps.python.org/pep-0632/#migration-advice) due to `distutils` module deprecation.