### PR TITLE
List resolved jiras also when user is specified as tester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ tmp/
 
 # VS Code
 .vscode
+.idea

--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -251,9 +251,9 @@ class JiraResolved(Stats):
         log.info("Searching for issues resolved in {0} by {1}".format(
             self.parent.project, self.user))
         query = (
-            "assignee = '{0}' AND "
-            "resolved >= {1} AND resolved <= {2}".format(
-                self.user.login or self.user.email,
+            "(assignee = '{0}' OR tester = '{1}') AND "
+            "resolved >= {2} AND resolved <= {3}".format(
+                self.user.login or self.user.email, self.user.login or self.user.email,
                 self.options.since, self.options.until))
         if self.parent.project:
             query = query + " AND project = '{0}'".format(


### PR DESCRIPTION
In our team we resolve jiras where the users of did are set as `tester` in some cases and not just as `assignee` - [here](https://issues.redhat.com/browse/ENTMQST-4857) is and example of task like that. To get these tasks as resolved via did we had to add these lines to the code (we maintained changes for some time).

Another option would be to introduce a new output like `Issues Verified in Jira - XXX` and put there all tasks where user is specified as `tester`. 