### PR TITLE
Ignore test credentials for the `google` plugin

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+[allowlist]
+description = "Global Allowlist"
+
+# Ignore based on any subset of the file path
+paths = [
+    # Test credentials for the google plugin
+    "tests/plugins/google-api-credentials.json",
+]


### PR DESCRIPTION
Instruct security scanners that the `google` plugin test credentials are intentionally stored in the repository.