### PR TITLE
Fix KeyError with user query result

### DIFF
--- a/did/plugins/gitlab.py
+++ b/did/plugins/gitlab.py
@@ -126,7 +126,7 @@ class GitLab(object):
                 ) from jde
         try:
             return result[0]
-        except IndexError:
+        except (IndexError, KeyError):
             raise ReportError(
                 "Unable to find user '{0}' on GitLab.".format(username))
 


### PR DESCRIPTION
The return object could be dictionary when failed auth, which could cause the KeyError exception. Fix it by also catch the KeyError.