### PR TITLE
public_inbox: Fix email threads without an available root message 

### DIFF
--- a/did/plugins/public_inbox.py
+++ b/did/plugins/public_inbox.py
@@ -145,7 +145,7 @@ class PublicInbox(object):
         log.warn("Couldn't find message root")
         return None
 
-    def __get_thread_root(self, msg: Message) -> typing.Optional[Message]:
+    def __get_thread_root(self, msg: Message) -> Message:
         log.debug("Looking for thread root of message %s" % msg.id())
         if msg.is_thread_root():
             log.debug("Message is thread root already. Returning.")
@@ -154,6 +154,10 @@ class PublicInbox(object):
         parent_id = msg.parent_id()
         if parent_id not in self.messages_cache:
             root = self.__fetch_thread_root(msg)
+            if root is None:
+                log.debug("Can't retrieve the thread root, returning.")
+                return msg
+
             log.debug("Found root message %s for message %s" % (root.id(), msg.id()))
             return root
 
@@ -167,7 +171,11 @@ class PublicInbox(object):
 
             parent_id = parent.parent_id()
             if parent_id not in self.messages_cache:
-                root = self.__fetch_thread_root(msg)
+                root = self.__fetch_thread_root(parent)
+                if root is None:
+                    log.debug("Can't retrieve the message parent, returning.")
+                    return parent
+
                 log.debug(
                     "Found root message %s for message %s" %
                     (root.id(), msg.id()))

--- a/did/plugins/public_inbox.py
+++ b/did/plugins/public_inbox.py
@@ -29,17 +29,17 @@ class Message(object):
     def __init__(self, msg: mailbox.mboxMessage) -> None:
         self.msg = msg
 
-    def __msg_id(self, keyid: str) -> str:
+    def __msg_id(self, keyid: str) -> typing.Optional[str]:
         msgid = self.msg[keyid]
         if msgid is None:
             return None
 
         return msgid.lstrip("<").rstrip(">")
 
-    def id(self) -> str:
+    def id(self) -> typing.Optional[str]:
         return self.__msg_id("Message-Id")
 
-    def parent_id(self) -> str:
+    def parent_id(self) -> typing.Optional[str]:
         return self.__msg_id("In-Reply-To")
 
     def subject(self) -> str:
@@ -129,7 +129,7 @@ class PublicInbox(object):
 
         return msgs
 
-    def __fetch_thread_root(self, msg: Message) -> Message:
+    def __fetch_thread_root(self, msg: Message) -> typing.Optional[Message]:
         msg_id = msg.id()
         url = self.__get_url("/all/%s/t.mbox.gz" % msg_id)
 
@@ -141,7 +141,7 @@ class PublicInbox(object):
                 log.debug("Found message %s thread root: %s." % (msg_id, msg.id()))
                 return msg
 
-    def __get_thread_root(self, msg: Message) -> Message:
+    def __get_thread_root(self, msg: Message) -> typing.Optional[Message]:
         log.debug("Looking for thread root of message %s" % msg.id())
         if msg.is_thread_root():
             log.debug("Message is thread root already. Returning.")

--- a/did/plugins/public_inbox.py
+++ b/did/plugins/public_inbox.py
@@ -143,6 +143,7 @@ class PublicInbox(object):
                 return msg
 
         log.warn("Couldn't find message root")
+        return None
 
     def __get_thread_root(self, msg: Message) -> typing.Optional[Message]:
         log.debug("Looking for thread root of message %s" % msg.id())

--- a/did/plugins/public_inbox.py
+++ b/did/plugins/public_inbox.py
@@ -32,6 +32,7 @@ class Message(object):
     def __msg_id(self, keyid: str) -> typing.Optional[str]:
         msgid = self.msg[keyid]
         if msgid is None:
+            log.debug("Missing header %s" % keyid)
             return None
 
         return msgid.lstrip("<").rstrip(">")
@@ -140,6 +141,8 @@ class PublicInbox(object):
             if msg.is_thread_root():
                 log.debug("Found message %s thread root: %s." % (msg_id, msg.id()))
                 return msg
+
+        log.warn("Couldn't find message root")
 
     def __get_thread_root(self, msg: Message) -> typing.Optional[Message]:
         log.debug("Looking for thread root of message %s" % msg.id())


### PR DESCRIPTION
Hi,

@stefano-garzarella and @javierm have been reporting on the public-inbox plugin https://github.com/psss/did/pull/329 that they were having crashes.

It turns out that lore doesn't always manage to archive all the messages and we might find emails with a valid in-reply-to header, but can't retrieve the message from the ML archive.

This was partly due to an improper type annotation, so this PR fixes both the type annotations and the actual bug they were both facing.