### PR TITLE
Drop support for `epel-8` and `python-3.8`

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,7 +13,6 @@ jobs:
   trigger: pull_request
   targets:
   - fedora-all
-  - epel-8
   - epel-9
   enable_net: False
 
@@ -21,7 +20,6 @@ jobs:
   trigger: pull_request
   targets:
   - fedora-all
-  - epel-8
   - epel-9
 
 - job: copr_build
@@ -29,7 +27,6 @@ jobs:
   branch: main
   targets:
   - fedora-all
-  - epel-8
   - epel-9
   enable_net: False
   list_on_homepage: True

--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ Install
 
 Install directly from Fedora/Copr repository::
 
-    yum install did
+    dnf install did
 
 Or use pip to install from Python Package Index::
 
@@ -237,7 +237,7 @@ Jakub Rozek and Petr Matyáš.
 Copyright
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Copyright (c) 2015 Red Hat, Inc. All rights reserved.
+Copyright Red Hat
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License as

--- a/did/base.py
+++ b/did/base.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """ Config, Date, User and Exceptions """
 
 import codecs

--- a/did/cli.py
+++ b/did/cli.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """
 Command line interface for did
 

--- a/did/plugins/bodhi.py
+++ b/did/plugins/bodhi.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Bodhi stats
 

--- a/did/plugins/bugzilla.py
+++ b/did/plugins/bugzilla.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """
 Bugzilla stats such as filed, fixed or verified bugs
 

--- a/did/plugins/confluence.py
+++ b/did/plugins/confluence.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Confluence stats such as created pages and comments
 

--- a/did/plugins/footer.py
+++ b/did/plugins/footer.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """
 Customizable footer
 

--- a/did/plugins/gerrit.py
+++ b/did/plugins/gerrit.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Gerrit stats such as submitted, review or merged changes
 

--- a/did/plugins/git.py
+++ b/did/plugins/git.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Git commits
 

--- a/did/plugins/github.py
+++ b/did/plugins/github.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 GitHub stats such as created and closed issues
 

--- a/did/plugins/gitlab.py
+++ b/did/plugins/gitlab.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 GitLab stats such as created and closed issues
 

--- a/did/plugins/google.py
+++ b/did/plugins/google.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 """
 Google stats such as attended events or completed tasks

--- a/did/plugins/header.py
+++ b/did/plugins/header.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Customizable header
 

--- a/did/plugins/items.py
+++ b/did/plugins/items.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Custom section with multiple items
 

--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Jira stats such as created, updated or resolved issues
 

--- a/did/plugins/koji.py
+++ b/did/plugins/koji.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Finished Koji builds
 

--- a/did/plugins/nitrate.py
+++ b/did/plugins/nitrate.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Nitrate stats such as created test plans, runs, cases
 

--- a/did/plugins/pagure.py
+++ b/did/plugins/pagure.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Pagure stats such as created/closed issues and pull requests.
 

--- a/did/plugins/phabricator.py
+++ b/did/plugins/phabricator.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Phabricator stats for authored and reviewed differentials, aka reviews.
 

--- a/did/plugins/public_inbox.py
+++ b/did/plugins/public_inbox.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Public-Inbox stats about mailing lists threads
 

--- a/did/plugins/redmine.py
+++ b/did/plugins/redmine.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Redmine stats
 

--- a/did/plugins/rt.py
+++ b/did/plugins/rt.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Request Tracker stats such as reported and resolved tickets
 

--- a/did/plugins/sentry.py
+++ b/did/plugins/sentry.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Sentry stats such as commented and resolved issues.
 

--- a/did/plugins/trac.py
+++ b/did/plugins/trac.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Trac stats such as created, accepted, updated and closed tickets
 

--- a/did/plugins/trello.py
+++ b/did/plugins/trello.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Trello actions such as created, moved or closed cards
 

--- a/did/plugins/wiki.py
+++ b/did/plugins/wiki.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 MoinMoin wiki stats about updated pages
 

--- a/did/plugins/zammad.py
+++ b/did/plugins/zammad.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Zammad stats such as updated tickets
 

--- a/did/stats.py
+++ b/did/stats.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """ Stats & StatsGroup, the core of the data gathering """
 
 import re

--- a/did/utils.py
+++ b/did/utils.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 """ Logging, config, constants & utilities """
 
 import importlib

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -36,7 +36,7 @@ Installing did using pip directly on the system is easy::
 Use virtual environments if you do not want to affect your system.
 Install virtualenv wrapper to make the work more comfortable::
 
-    sudo yum install python-virtualenvwrapper   # Fedora
+    sudo dnf install python-virtualenvwrapper   # Fedora
     sudo apt install virtualenvwrapper          # Ubuntu
 
 Create a new virtual environment, upgrade tools, install did::
@@ -58,7 +58,7 @@ dependencies, for example::
 Note: For plugins depending on gssapi (jira & rt) there are some
 extra dependencies::
 
-    sudo yum install gcc krb5-devel python-devel    # Fedora
+    sudo dnf install gcc krb5-devel python-devel    # Fedora
     sudo apt install gcc libkrb5-dev python-dev     # Ubuntu
 
 See the `pypi package index`__ for detailed package information.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# coding: utf-8
 
 import re
 
@@ -59,12 +58,12 @@ setup(
 
     keywords=['status', 'report', 'tasks', 'work'],
     classifiers=[
-        'License :: OSI Approved :: '
-            'GNU General Public License v2 or later (GPLv2+)',
+        'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Office/Business',
         'Topic :: Utilities',
         ],


### PR DESCRIPTION
Stop building and testing for `epel-8`.
Drop unnecessary `coding: utf-8` lines.
Adjust supported Python versions accordingly.
Plus a couple of minor documentation adjustments.