### PR TITLE
Fetch all created issues correctly in `pagure`

### DIFF
--- a/did/plugins/pagure.py
+++ b/did/plugins/pagure.py
@@ -111,7 +111,7 @@ class IssuesCreated(Stats):
     def fetch(self):
         log.info('Searching for issues created by {0}'.format(self.user))
         issues = [Issue(issue, self.options) for issue in self.parent.pagure.search(
-            query='user/{0}/issues?assignee=false&created={1}..{2}'.format(
+            query='user/{0}/issues?status=all&created={1}..{2}'.format(
                 self.user.login, self.options.since, self.options.until),
             pagination='pagination_issues_created',
             result_field='issues_created')]


### PR DESCRIPTION
Original query reports 6 created issues that are not closed:

https://pagure.io/api/0/user/mikelo2/issues?assignee=false&created=2024-01-01..2025-01-01

While the new one reports 169 created issues:

https://pagure.io/api/0/user/mikelo2/issues?status=all&created=2024-01-01..2025-01-01