### PR TITLE
Drop `distutils`, implement custom `strtobool`

### DIFF
--- a/did/plugins/confluence.py
+++ b/did/plugins/confluence.py
@@ -31,7 +31,6 @@ Notes:
   higher priority.
 """
 
-import distutils.util
 import os
 import re
 import urllib.parse
@@ -42,7 +41,7 @@ from requests_gssapi import DISABLED, HTTPSPNEGOAuth
 
 from did.base import Config, ReportError
 from did.stats import Stats, StatsGroup
-from did.utils import listed, log, pretty
+from did.utils import listed, log, pretty, strtobool
 
 # Maximum number of results fetched at once
 MAX_RESULTS = 100
@@ -213,7 +212,7 @@ class ConfluenceStats(StatsGroup):
         # SSL verification
         if "ssl_verify" in config:
             try:
-                self.ssl_verify = distutils.util.strtobool(
+                self.ssl_verify = strtobool(
                     config["ssl_verify"])
             except Exception as error:
                 raise ReportError(

--- a/did/plugins/gitlab.py
+++ b/did/plugins/gitlab.py
@@ -23,7 +23,6 @@ __ https://docs.gitlab.com/ce/api/
 
 """
 
-import distutils.util
 from time import sleep
 
 import dateutil
@@ -32,7 +31,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 from did.base import Config, ReportError, get_token
 from did.stats import Stats, StatsGroup
-from did.utils import listed, log, pretty
+from did.utils import listed, log, pretty, strtobool
 
 GITLAB_SSL_VERIFY = True
 GITLAB_API = 4
@@ -381,7 +380,7 @@ class GitLabStats(StatsGroup):
                 "No GitLab token set in the [{0}] section".format(option))
         # Check SSL verification
         try:
-            self.ssl_verify = bool(distutils.util.strtobool(
+            self.ssl_verify = bool(strtobool(
                 config["ssl_verify"]))
         except KeyError:
             self.ssl_verify = GITLAB_SSL_VERIFY

--- a/did/plugins/jira.py
+++ b/did/plugins/jira.py
@@ -77,7 +77,6 @@ Notes:
   Other values are ``basic`` and ``token``.
 """
 
-import distutils.util
 import os
 import re
 import urllib.parse
@@ -89,7 +88,7 @@ from requests_gssapi import DISABLED, HTTPSPNEGOAuth
 
 from did.base import Config, ReportError, get_token
 from did.stats import Stats, StatsGroup
-from did.utils import listed, log, pretty
+from did.utils import listed, log, pretty, strtobool
 
 # Maximum number of results fetched at once
 MAX_RESULTS = 1000
@@ -344,7 +343,7 @@ class JiraStats(StatsGroup):
         # SSL verification
         if "ssl_verify" in config:
             try:
-                self.ssl_verify = distutils.util.strtobool(
+                self.ssl_verify = strtobool(
                     config["ssl_verify"])
             except Exception as error:
                 raise ReportError(
@@ -355,7 +354,7 @@ class JiraStats(StatsGroup):
         # Make sure we have project set
         self.project = config.get("project", None)
         if "use_scriptrunner" in config:
-            self.use_scriptrunner = distutils.util.strtobool(
+            self.use_scriptrunner = strtobool(
                 config["use_scriptrunner"])
         else:
             self.use_scriptrunner = True

--- a/did/utils.py
+++ b/did/utils.py
@@ -185,6 +185,33 @@ def shorted(text, width=MAX_WIDTH):
     return "\n".join(lines)
 
 
+def strtobool(value):
+    """
+    Convert various boolean formats to True (1) or False (0).
+    """
+
+    value = str(value).lower()
+    mapping = {
+        "y": 1,
+        "yes": 1,
+        "t": 1,
+        "true": 1,
+        "on": 1,
+        "1": 1,
+        "n": 0,
+        "no": 0,
+        "f": 0,
+        "false": 0,
+        "off": 0,
+        "0": 0,
+        }
+
+    try:
+        return mapping[value]
+    except KeyError:
+        raise ValueError(f"Invalid boolean value '{value}'.")
+
+
 def item(text, level=0, options=None):
     """ Print indented item. """
     # Extra line before in each section (unless brief)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 import did
+from did.utils import strtobool
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Constants
@@ -150,3 +151,29 @@ def test_Coloring():
 def test_color():
     from did.utils import color
     assert color
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  strtobool
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+def test_strtobool():
+    # True
+    assert strtobool("yes") == 1
+    assert strtobool("y") == 1
+    assert strtobool("on") == 1
+    assert strtobool("true") == 1
+    assert strtobool("True") == 1
+    assert strtobool("TRUE") == 1
+    assert strtobool("1") == 1
+    assert strtobool(1) == 1
+
+    # False
+    assert strtobool("no") == 0
+    assert strtobool("n") == 0
+    assert strtobool("off") == 0
+    assert strtobool("false") == 0
+    assert strtobool("False") == 0
+    assert strtobool("FALSE") == 0
+    assert strtobool("0") == 0
+    assert strtobool(0) == 0


### PR DESCRIPTION
Let's implement a simple `strtobool()` function in `did.utils`. This replaces #355 as it does not make much sense to introduce a new license just because of such a basic functionality.