### PR TITLE
Reenable `import-error` pylint test

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+---
 name: pre-commit
 
 on:
@@ -9,18 +10,17 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
-    # ensure all dependencies are available to satisfy pylint pre-commit hook checks
-    - run: sudo apt-get install -y libkrb5-dev python3-pytest
-    - run: python -m venv --system-site-packages .venv
-    - run: source .venv/bin/activate
-    - run: python -m pip install pre-commit
-    - run: python -m pip install --upgrade '.[all]'  --upgrade-strategy eager
-    - uses: actions/cache@v4
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - run: pre-commit run --show-diff-on-failure --color=always --all-files
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      # ensure all dependencies are available to satisfy pylint pre-commit hook checks
+      - run: sudo apt-get install -y libkrb5-dev python3-pytest
+      - run: python -m venv --system-site-packages .venv
+      - run: source .venv/bin/activate && pip install --upgrade pip setuptools pre-commit
+      - run: source .venv/bin/activate && python -m pip install --upgrade '.[all]'  --upgrade-strategy eager
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - run: source .venv/bin/activate && pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.pylintrc
+++ b/.pylintrc
@@ -3,4 +3,4 @@ ignore-paths=^bin/.*$
 init-hook='import sys; sys.path.append("./.venv/lib64/python3.13/site-packages"); sys.path.append("/usr/lib/python3.13/site-packages")'
 
 [MESSAGES]
-disable=duplicate-code,missing-function-docstring,missing-module-docstring,missing-class-docstring,fixme,too-many-arguments,too-many-instance-attributes,import-error
+disable=duplicate-code,missing-function-docstring,missing-module-docstring,missing-class-docstring,fixme,too-many-arguments,too-many-instance-attributes

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,6 @@
 [MAIN]
 ignore-paths=^bin/.*$
-init-hook='import sys; sys.path.append("./.venv/lib64/python3.13/site-packages"); sys.path.append("/usr/lib/python3.13/site-packages")'
+init-hook='import sys; import site; sys.path.extend(site.getsitepackages()); sys.path.append("./.venv/lib64/python3.13/site-packages"); sys.path.append("/usr/lib/python3.13/site-packages")'
 
 [MESSAGES]
 disable=duplicate-code,missing-function-docstring,missing-module-docstring,missing-class-docstring,fixme,too-many-arguments,too-many-instance-attributes


### PR DESCRIPTION
Fixed the `pre-commit` github action so it can now run the `import-error` pylint test properly.