### PR TITLE
Drop deprecated license classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
 
     keywords=['status', 'report', 'tasks', 'work'],
     classifiers=[
-        'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Natural Language :: English',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
license classifier has been deprecated in favor of the license expression field.

See https://peps.python.org/pep-0639/

Fixes:

```console
/usr/lib/python3.13/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```