### PR TITLE
Update spec to 2021+ guidelines

### DIFF
--- a/did.spec
+++ b/did.spec
@@ -27,7 +27,6 @@ Requires: python3-requests-gssapi
 Requires: python3-feedparser
 Requires: python3-tenacity
 
-%?python_enable_dependency_generator
 
 %description
 Comfortably gather status report data (e.g. list of committed
@@ -37,23 +36,26 @@ range. By default all available stats for this week are reported.
 %prep
 %autosetup -S git
 
+%generate_buildrequires
+%pyproject_buildrequires
+
+
 %build
-%py3_build
+%pyproject_wheel
 
 %install
-%py3_install
+%pyproject_install
+%pyproject_save_files did
 mkdir -p %{buildroot}%{_mandir}/man1
 install -pm 644 did.1.gz %{buildroot}%{_mandir}/man1
 
 %check
 export LANG=en_US.utf-8
-%{__python3} -m pytest -vv tests/test*.py -k 'not smoke'
+%pytest -vv tests/test*.py -k 'not smoke'
 
-%files
+%files -f %{pyproject_files}
 %{_mandir}/man1/*
 %{_bindir}/did
-%{python3_sitelib}/%{name}/
-%{python3_sitelib}/%{name}-*.egg-info/
 %doc README.rst examples
 %license LICENSE
 


### PR DESCRIPTION
Updated spec file to conform to Fedora Packaging Guidelines for Python 2021 edition
(https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/)

Fixes:

```console
$ /usr/bin/python3 setup.py install -O1 --skip-build --root /builddir/build/BUILD/did-0.21-build/BUILDROOT --prefix /usr
running install
/usr/lib/python3.13/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        Follow the current Python packaging guidelines when building
        Python RPM packages.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html
        and https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/ for details.
        ********************************************************************************

!!
```

observed in copr build: https://download.copr.fedorainfracloud.org/results/packit/psss-did-397/fedora-42-x86_64/09095166-did/builder-live.log.gz