### PR TITLE
Deal with conflicting period options

### DIFF
--- a/did/cli.py
+++ b/did/cli.py
@@ -136,6 +136,10 @@ class Options():
         if opt.since is None and opt.until is None:
             opt.since, opt.until, period = did.base.Date.period(arg)
         else:
+            if self.arg:
+                raise did.base.OptionError(
+                    f'Can\'t use --since or --until with \'{" ".join(self.arg)}\''
+                    )
             opt.since = did.base.Date(opt.since or "1993-01-01")
             opt.until = did.base.Date(opt.until or "today")
             # Make the 'until' limit inclusive

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,3 +63,11 @@ def test_invalid_date():
     for argument in ["--since x", "--since 2015-16-17"]:
         with pytest.raises(did.base.OptionError):
             did.cli.main(argument)
+
+
+def test_conflicting_options():
+    """ Complain about conflicting options """
+    did.base.Config(config=MINIMAL)
+    for argument in ["last week --since 2025-05-29", "last week --until 2025-05-29"]:
+        with pytest.raises(did.base.OptionError):
+            did.cli.main(argument)


### PR DESCRIPTION
When since/until options are used with relative time issue an error explaining it's not possible to specify both relative and absolute periods at the same time.

The error emitted looks like:

```console
$ did last week --since 2025-05-22
 ERROR  Can't use --since or --until with 'last week'
```

Fixes #81