### PR TITLE
Use the correct class for `until` in the `github` plugin

### DIFF
--- a/did/plugins/github.py
+++ b/did/plugins/github.py
@@ -52,7 +52,7 @@ import requests
 from tenacity import (RetryError, Retrying, retry_if_exception_type,
                       stop_after_attempt)
 
-from did.base import Config, ReportError, get_token
+from did.base import Config, Date, ReportError, get_token
 from did.stats import Stats, StatsGroup
 from did.utils import listed, log, pretty
 
@@ -126,7 +126,7 @@ class GitHub():
     @staticmethod
     def until(until):
         """Issue #362: until for GH should have - delta(day=1)"""
-        return until - 1
+        return Date(until - 1)
 
     def request(self, url):
         while True:

--- a/tests/github/main.fmf
+++ b/tests/github/main.fmf
@@ -2,6 +2,12 @@
     summary: Check the help message and option sanity
     test: ./help.sh
 
+/basic:
+    summary: Check stats for the last week
+    description: Ensures that all stats are sane
+    framework: shell
+    test: did --config ./config-default.ini
+
 /pulls:
     summary: Verify pull request stats
     test: ./pulls.sh


### PR DESCRIPTION
Fix regression introduced in #376. The `until` date should use the `did.base.Date` class. Otherwise stats like commented issues traceback because of the missing `datetime` attribute. Include a basic sanity coverage which exercises all stats to prevent similar issues in the future.