### PR TITLE
Handle error responses querying GitHub

### DIFF
--- a/did/plugins/github.py
+++ b/did/plugins/github.py
@@ -176,9 +176,20 @@ class GitHub():
             # Fetch the query
             log.debug("GitHub query: %s", url)
             response = self.request(url)
+            if not response.ok:
+                try:
+                    error = json.loads(response.text)["errors"][0]["message"]
+                except KeyError:
+                    error = "unknown"
+                raise ReportError(
+                    f"Failed to fetch GitHub data at '{url}'. "
+                    f"The reason was '{response.reason}' "
+                    f"and the error was '{error}'.")
+            log.data(pretty(response.text))
             # Parse fetched json data
             try:
                 data = json.loads(response.text)["items"]
+                log.debug(data)
                 result.extend(data)
             except requests.exceptions.JSONDecodeError as error:
                 log.debug(error)

--- a/tests/plugins/test_github.py
+++ b/tests/plugins/test_github.py
@@ -122,6 +122,25 @@ def test_github_missing_url(caplog: LogCaptureFixture):
         assert "Skipping section gh due to error: No github url set" in caplog.text
 
 
+def test_github_wrong_user(caplog: LogCaptureFixture):
+    """
+    Test non existing user error reporting
+    @see: https://github.com/psss/did/issues/101
+    """
+    did.base.Config("""
+                    [general]
+                    email = "Petr Splichal" <psplicha@redhat.com>
+
+                    [gh]
+                    type = github
+                    url = https://api.github.com/
+                    login = nonexistantuser
+                    """)
+    with caplog.at_level(logging.ERROR):
+        did.cli.main(INTERVAL)
+        assert "The listed users cannot be searched" in caplog.text
+
+
 def test_github_unicode():
     """ Created issues with Unicode characters """
     did.base.Config("[gh]\ntype = github\nurl = https://api.github.com/")


### PR DESCRIPTION
Previously there was no check on the goodness of the response received from GitHub. Now the response is checked and error is reported accordingly.

Fixes #101