### PR TITLE
Add `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Following https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#modernize-setup-py-project introduced a minimal `pyproject.toml` setting `setuptools` build backend.