### PR TITLE
Add type annotations on `base.py`

### DIFF
--- a/did/plugins/items.py
+++ b/did/plugins/items.py
@@ -32,7 +32,7 @@ class ItemStats(Stats):
             parent: Optional[StatsGroup] = None):
         # Prepare sorted item content from the config section
         items = Config().section(
-            option.replace("-item", ""), skip=["type", "header", "order"]
+            option.replace("-item", ""), skip=("type", "header", "order")
             )
         super().__init__(option, name, parent)
         # items can use '|' as first character to preserve


### PR DESCRIPTION
- Add type annotations to function signatures, variables and constants in `did/base.py`
- Add runtime checks for `Config.parser` initialization with proper error handling
- Convert mutable default arguments from lists to tuples in `items.py`, matching types in `base.py`
- Add return type annotations to all test functions
- Fix test assertions to use correct module references (`did.utils` vs `did.base`)
- Update test data structures from strings to lists for better type consistency
- Split and reorganize test functions for better maintainability
- Import `Iterator` type for proper context manager typing