### PR TITLE
Fix parsing of `--config` argument with whitespace

### DIFF
--- a/did/base.py
+++ b/did/base.py
@@ -264,8 +264,8 @@ class Config():
             if matched:
                 if matched.groups()[0] is not None:
                     arg = matched.groups()[0]
-                elif i+1 < len(sys.argv):
-                    arg = sys.argv[i+1]
+                elif i + 1 < len(sys.argv):
+                    arg = sys.argv[i + 1]
                 else:
                     arg = ""
                 filepath, filename = os.path.split(arg)


### PR DESCRIPTION
Uses argv properly instead of concatenating all arguments in a single string and searching for the --config argument inside it.

Fixes also some other corner cases:
- The "--config " string in the middle of another arguemnt is not interpereted as a --config argument anymore.
- "--confg" argument is not accepted anymore (used to be an alias for --config).

Before:
- `did  --help --conf "System roles/sconf.did"`
```
Create at least a minimum config file /home/pcahyna/.did/System:
[general]
email = Name Surname <email@example.org>
 ERROR  Unable to read the config file '/home/pcahyna/.did/System'.
```
- `did  --help  --email "Samuel--conf <sconf@example.com>" --conf "System roles/sconf.did"`
```
Create at least a minimum config file /home/pcahyna/.did/<sconf@example.com>:
[general]
email = Name Surname <email@example.org>
 ERROR  Unable to read the config file '/home/pcahyna/.did/<sconf@example.com>'.
```
- `did  --help --confg "test/sconf.did"`
_\<help text\>_

After:
- `did  --help --conf "System roles/sconf.did"`
_\<help text\>_
- `did  --help  --email "Samuel--conf <sconf@example.com>" --conf "System roles/sconf.did"`
_\<help text\>_
- `did  --help --confg "test/sconf.did"`
```
Create at least a minimum config file /home/pcahyna/.did/config:
[general]
email = Name Surname <email@example.org>
 ERROR  Unable to read the config file '/home/pcahyna/.did/config'.
```