### PR TITLE
Enable Python 3.14 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
           - --max-line-length=88
 
   - repo: https://github.com/PyCQA/isort
-    rev: "6.0.1"
+    rev: "7.0.0"
     hooks:
       - id: isort
 
@@ -25,7 +25,8 @@ repos:
       - id: flake8
         additional_dependencies:
           [
-            flake8-pytest-style == 2.1.0,
+            # https://pypi.org/project/flake8-pytest-style/
+            flake8-pytest-style == 2.2.0,
           ]
         args:
           - --config
@@ -45,7 +46,7 @@ repos:
           )$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v5.0.0"
+    rev: "v6.0.0"
     hooks:
       - id: end-of-file-fixer
       - id: mixed-line-ending
@@ -56,7 +57,7 @@ repos:
         exclude: disable_test_trac.py
 
   - repo: https://github.com/pylint-dev/pylint
-    rev: "v3.3.7"
+    rev: "v4.0.2"
     hooks:
       - id: pylint
         args:
@@ -82,7 +83,7 @@ repos:
           ]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.17.0'
+    rev: 'v1.18.2'
     hooks:
       - id: mypy
         exclude: examples/.*|bin/did

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,6 @@
 [MAIN]
 ignore-paths=^bin/.*$
-init-hook='import sys; import site; sys.path.extend(site.getsitepackages()); sys.path.append("./.venv/lib64/python3.13/site-packages"); sys.path.append("/usr/lib/python3.13/site-packages")'
+init-hook='import sys; import site; sys.path.extend(site.getsitepackages()); sys.path.append("./.venv/lib64/python3.14/site-packages"); sys.path.append("/usr/lib/python3.13/site-packages")'
 
 [MESSAGES]
 disable=duplicate-code,missing-function-docstring,missing-module-docstring,missing-class-docstring,fixme,too-many-arguments,too-many-instance-attributes

--- a/did/base.py
+++ b/did/base.py
@@ -1,6 +1,5 @@
 """ Config, Date, User and Exceptions """
 
-import codecs
 import configparser
 import contextlib
 import datetime
@@ -129,7 +128,7 @@ class Config():
         # Parse the config from file
         try:
             log.info("Inspecting config file '%s'.", path)
-            with codecs.open(path, "r", "utf8") as config_file:
+            with open(path, "r", encoding="utf8") as config_file:
                 Config.parser.read_file(config_file)
         except IOError as error:
             log.debug(error)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ extras_require = {
     'redmine': ['feedparser'],
     'nitrate': ['nitrate'],
     'rt': ['gssapi'],
-    'tests': ['pytest', 'pytest-xdist', 'pytest-cov', 'python-coveralls', 'pre-commit'],
+    'tests': ['pytest', 'pytest-xdist', 'pytest-cov', 'python-coveralls', 'pre-commit',
+              'setuptools'],
     'mypy': ['types-setuptools', 'types-python-dateutil', 'lxml',
              'types-requests', 'types-urllib3', 'types-httplib2'],
     }
@@ -75,6 +76,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Office/Business',
         'Topic :: Utilities',
         ],


### PR DESCRIPTION
- Dropped usage of deprecated module codecs
- Added Python 3.14 to setup.py
- Update pre-commit and pylint config accordingly

Fixes #439