### PR TITLE
Add type hints to items plugin

### DIFF
--- a/did/plugins/items.py
+++ b/did/plugins/items.py
@@ -13,7 +13,7 @@ Config example::
 
 from typing import Optional
 
-from did.base import Config
+from did.base import Config, User
 from did.stats import Stats, StatsGroup
 from did.utils import item
 
@@ -42,11 +42,11 @@ class ItemStats(Stats):
             for _, value in sorted(items, key=lambda x: x[0])
             ]
 
-    def header(self):
+    def header(self) -> None:
         """ Simple header for custom stats (no item count) """
         item(self.name, 0, options=self.options)
 
-    def fetch(self):
+    def fetch(self) -> None:
         self.stats = self._items
 
 
@@ -56,7 +56,11 @@ class CustomStats(StatsGroup):
     # Default order
     order = 800
 
-    def __init__(self, option, name=None, parent=None, user=None):
+    def __init__(self,
+                 option: str,
+                 name: Optional[str] = None,
+                 parent: Optional[StatsGroup] = None,
+                 user: Optional[User] = None) -> None:
         super().__init__(option, name, parent, user)
         self.stats.append(
             ItemStats(

--- a/tests/plugins/test_items.py
+++ b/tests/plugins/test_items.py
@@ -30,7 +30,7 @@ item2 = Task Two
 """
 
 
-def test_item_with_indented_content():
+def test_item_with_indented_content() -> None:
     did.base.Config(CONFIG)
     stats = did.plugins.items.CustomStats("projects")
     stats.check()
@@ -44,17 +44,17 @@ def test_item_with_indented_content():
         ]
 
 
-def test_item_with_wrongly_ordered_content():
+def test_item_with_wrongly_ordered_content() -> None:
     did.base.Config(CONFIG)
     stats = did.plugins.items.CustomStats("tasks")
     stats.check()
     assert len(stats.stats) == 1
     assert stats.stats[0].name == "Work on tasks"
     assert stats.stats[0].stats == ['Task One', 'Task Two', 'Task Three']
-    assert stats.header() is None
+    stats.header()
 
 
-def test_items_ordering():
+def test_items_ordering() -> None:
     config = did.base.Config(CONFIG)
     user_stats = did.stats.UserStats(
         user=did.base.User(email=config.email), config=config


### PR DESCRIPTION
- Add return type annotations to header() and fetch() methods
- Add type hints to CustomStats.__init__ parameters
- Import User type from did.base
- Fix test assertion to properly call header() method