### PR TITLE
Fix `GitHub.commented_in_range`

### DIFF
--- a/did/plugins/github.py
+++ b/did/plugins/github.py
@@ -296,7 +296,11 @@ class IssueCommented(Stats):
         login = self.user.login
         since = self.options.since
         until = GitHub.until(self.options.until)
-        query = f"search/issues?q=commenter:{login}+updated:{since}..*+type:issue"
+        query = (
+            f"search/issues?q=commenter:{login}+updated:{since}..*+type:issue"
+            # Filter out Issues created after 'until'
+            f"+created:*..{until}"
+            )
         commented_issues = self.parent.github.search(query)
         valid_issues = self.parent.github.commented_in_range(
             commented_issues, since.datetime, until.datetime, login
@@ -326,7 +330,11 @@ class PullRequestsCommented(Stats):
         login = self.user.login
         since = self.options.since
         until = GitHub.until(self.options.until)
-        query = f"search/issues?q=commenter:{login}+updated:{since}..*+type:pr"
+        query = (
+            f"search/issues?q=commenter:{login}+updated:{since}..*+type:pr"
+            # Filter out PRs created after 'until'
+            f"+created:*..{until}"
+            )
         commented_issues = self.parent.github.search(query)
         valid_issues = self.parent.github.commented_in_range(
             commented_issues, since.datetime, until.datetime, login


### PR DESCRIPTION
Unfortunately, the current code doesn't cover many edge cases for large/old PRs and issues. Here are the cases that I address in the PR:

- The page size in GitHub is 30, so only 30 comments are fetched
- Pagination is not used at all
- If a PR/issue was updated after `until`, it will be filtered out by the first `search` query
- The `since` parameter isn't used. For huge issues/PRs, it helps to reduce the number of requests significantly

```
> gh api 'repos/ClickHouse/ClickHouse/issues/90542/comments?per_page=100&since=2025-11-20T00:00:00' | jq '.[] | .created_at'
"2025-11-20T23:55:00Z"
"2025-11-21T00:12:32Z"
"2025-11-21T09:56:12Z"
> gh api 'repos/ClickHouse/ClickHouse/issues/90542/comments?per_page=100&since=2025-11-21T00:00:00' | jq '.[] | .created_at'
"2025-11-21T00:12:32Z"
"2025-11-21T09:56:12Z"
```