### PR TITLE
Fix issues reported by CodeQL security scan

### DIFF
--- a/did/stats.py
+++ b/did/stats.py
@@ -27,8 +27,6 @@ class Stats():
     dest: str
     user: Optional[did.base.User]
     parent: Optional[StatsGroup] = None
-    # stats can be a list of any type as long as it implements __str__
-    stats: list[Any]
 
     def __init__(
             self, /,
@@ -42,7 +40,7 @@ class Stats():
         self.dest = self.option.replace("-", "_")
         self._name = name
         self.parent = parent
-        self.stats = []
+        self._stats: list[Any] = []
         # Save user and options (get it directly or from parent)
         self.options = options or getattr(self.parent, 'options', None)
         if user is None and self.parent is not None:
@@ -50,6 +48,15 @@ class Stats():
         else:
             self.user = user
         log.debug('Loading %s Stats instance for %s', option, self.user)
+
+    @property
+    def stats(self) -> list[Any]:
+        """Stats list; subclasses may override this property."""
+        return self._stats
+
+    @stats.setter
+    def stats(self, value: list[Any]) -> None:
+        self._stats = value
 
     @property
     def name(self) -> str:

--- a/did/utils.py
+++ b/did/utils.py
@@ -13,7 +13,7 @@ from pprint import pformat as pretty  # noqa: F401 (used by other modules)
 from types import ModuleType
 from typing import Any, Literal, Optional, Type, Union, cast
 
-__all__ = ["pretty"]
+__all__ = ["pretty", "EMAIL_REGEXP"]
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Constants
@@ -50,7 +50,8 @@ LOG_ALL = 1
 
 # Extract name and email from string
 # See: http://stackoverflow.com/questions/14010875
-EMAIL_REGEXP = re.compile(r'(?:"?([^"]*)"?\s)?(?:<?(.+@[^>]+)>?)')
+EMAIL_REGEXP = re.compile(   # noqa: F401 (used by other modules)
+    r'(?:"?([^"]*)"?\s)?(?:<?(.+@[^>]+)>?)')
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- did/stats.py: Replace mutable class attribute 'stats' with a property backed by instance _stats to avoid shared mutable state.
- did/utils.py: Export EMAIL_REGEXP in __all__ and add noqa for re-export.

Addresses findings from GitHub CodeQL code scanning: https://github.com/psss/did/security/code-scanning