### PR TITLE
Consider GitHub PR review comments

### DIFF
--- a/did/plugins/github.py
+++ b/did/plugins/github.py
@@ -128,6 +128,36 @@ class GitHub():
             condition("+-org", exclude_org)
             )
 
+    def issue_pr_commented_in_range(self,
+                                    issue_pr_url: str,
+                                    since: datetime,
+                                    until: datetime,
+                                    login: str) -> bool:
+        issue_checked = False
+        url = issue_pr_url
+        while not issue_checked:
+            response = self.request(url)
+            comments = response.json()
+            log.debug("%s comments fetched for %s", len(comments), url)
+            log.data(pretty(comments))
+            for comment in comments:
+                created_at = datetime.strptime(
+                    comment["created_at"],
+                    r"%Y-%m-%dT%H:%M:%SZ"
+                    )
+                if created_at > until:
+                    # Comments are sorted by created_at asc
+                    issue_checked = True
+                    break
+                if comment["user"]["login"] == login and since <= created_at:
+                    issue_checked = True
+                    return True
+            if 'next' in response.links:
+                url = response.links['next']['url']
+            else:
+                issue_checked = True
+        return False
+
     def commented_in_range(self,
                            commented_issues: list,
                            since: datetime,
@@ -136,33 +166,12 @@ class GitHub():
         valid_issues = []
         for issue in commented_issues:
             issue_since = since
-            issue_checked = False
             url = (
                 f"{issue['comments_url']}"
                 f"?per_page={PER_PAGE}&since={issue_since.isoformat()}"
                 )
-            while not issue_checked:
-                response = self.request(url)
-                comments = response.json()
-                log.debug("%s comments fetched for %s", len(comments), url)
-                log.data(pretty(comments))
-                for comment in comments:
-                    created_at = datetime.strptime(
-                        comment["created_at"],
-                        r"%Y-%m-%dT%H:%M:%SZ"
-                        )
-                    if created_at > until:
-                        # Comments are sorted by created_at asc
-                        issue_checked = True
-                        break
-                    if comment["user"]["login"] == login and since <= created_at:
-                        valid_issues.append(issue)
-                        issue_checked = True
-                        break
-                if 'next' in response.links:
-                    url = response.links['next']['url']
-                else:
-                    issue_checked = True
+            if self.issue_pr_commented_in_range(url, since, until, login):
+                valid_issues.append(issue)
         return valid_issues
 
     @staticmethod

--- a/did/plugins/github.py
+++ b/did/plugins/github.py
@@ -170,8 +170,28 @@ class GitHub():
                 f"{issue['comments_url']}"
                 f"?per_page={PER_PAGE}&since={issue_since.isoformat()}"
                 )
-            if self.issue_pr_commented_in_range(url, since, until, login):
+            if self.issue_pr_commented_in_range(url, since,
+                                                until, login):
                 valid_issues.append(issue)
+                continue
+            # If the issue is a PR, retry with review comments, these
+            # are different from issue comments:
+            # https://docs.github.com/en/rest/pulls/comments?apiVersion=2026-03-10
+            pr_dict = issue.get('pull_request')
+            if pr_dict:
+                # pr_dict is a small dict that contains the actual
+                # pull request URL.
+                response = self.request(pr_dict['url'])
+                # the full PR dict, contains different fields
+                # than the issue dict even if the issue is actually a PR
+                pr = response.json()
+                url = (
+                    f"{pr['review_comments_url']}"
+                    f"?per_page={PER_PAGE}&since={issue_since.isoformat()}"
+                    )
+                if self.issue_pr_commented_in_range(url, since,
+                                                    until, login):
+                    valid_issues.append(issue)
         return valid_issues
 
     @staticmethod


### PR DESCRIPTION
Review comments on GitHub PR diffs are different from ordinary comments in the discussion. The latter can be fetched for PRs just as for issues, as every PR is also an issue. But review comments on diffs need to be fetched in a different way - by requesting them from the PR endpoint like `https://api.github.com/repos/OWNER/REPO/pulls/PULL_NUMBER/comments`, not from the issue endpoint like `https://api.github.com/repos/OWNER/REPO/issues/ISSUE_NUMBER/comments` . See the API documentation: https://docs.github.com/en/rest/pulls/comments?apiVersion=2026-03-10
    
The current code has been doing only the latter and not the former, missing review comments on diffs in the GitHub activity report. Fix that.

As an example, consider this repo : https://github.com/pcahyna/filter_test. PRs https://github.com/pcahyna/filter_test/pull/1 and https://github.com/pcahyna/filter_test/pull/2 have review comments (the former from jridky and pcahyna, the latter from pcahyna). But the reports produced by the commands
```
did --debug --width 120 --config="./pcahyna.did" --since="2026-03-27" --until="2026-03-30" --email ".... ;github:pcahyna"
```
and 
```
did --debug --width 120 --config="./jridky.did" --since="2026-03-27" --until="2026-03-30" --email ".... ;github:jridky"
```
contain only nothing and
```
* Pull requests commented on github: 1
    * pcahyna/filter_test#003 - Dummy commit to attract comments.
```
respectively (the latter PR because it was commented by jridky in the discussion).

This PR fixes that, the outputs are now
```
* Pull requests commented on github: 2
    * pcahyna/filter_test#002 - Dummy commit to attract comments.
    * pcahyna/filter_test#001 - Dummy commit to attract comments.
```
and
```
* Pull requests commented on github: 2
    * pcahyna/filter_test#003 - Dummy commit to attract comments.
    * pcahyna/filter_test#001 - Dummy commit to attract comments.
```
respectively.

Note that the review comment appear among "Pull requests commented on github", not "Pull requests reviewed on github" and it is possible that some of them will also appear duplicate in the "Pull requests reviewed on github" section. I decided to include them in the "commented" section, because the filter that produces the "reviewed" section is quite restrictive, as it is of the type:
`https://api.github.com/search/issues?q=reviewed-by:pcahyna+-author:pcahyna+closed:2026-03-27..2026-03-30+type:pr+repo:pcahyna/filter_test&per_page=100`
Note that it includes only PRs that were not just reviewed but actually closed (this was noted in issue #370) and excludes reviews by the PR authors (which perhaps makes sense for reviews like approvals, but IMO not for review comments on code diffs, as the latter are discussions and should count as activity). I did not want to touch these design choices.

Note also that according to https://github.com/psss/did/issues/325#issuecomment-2022190876 it is unnecessary to use the PR comments endpoint, as PullRequestsReviewed has a very solid query. I disagree, because of the reasons above - the query is too restrictive.