### PR TITLE
Add --version / -V flag under did cli

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ Gather stats for the last month::
     did last month
 
 See ``did --help`` for complete list of available stats.
+Use ``did --version`` (or ``-V``) to print the installed version.
 
 
 Options

--- a/did/cli.py
+++ b/did/cli.py
@@ -16,6 +16,7 @@ import did.base
 from did import utils
 from did.stats import UserStats
 from did.utils import log
+from did.version import get_version
 
 USAGE = """
 did [this|last] [week|month|quarter|year] [options]
@@ -26,6 +27,15 @@ Comfortably gather status report data for given week, month,
 quarter, year or selected date range. By default all available
 stats for this week are reported.
 """.strip()
+
+
+def _argv_list(arguments: Union[None, str, list[str]]) -> list[str]:
+    """Command-line tokens to parse (excluding program name)."""
+    if arguments is None:
+        return sys.argv[1:]
+    if isinstance(arguments, str):
+        return arguments.split()
+    return list(arguments)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -110,6 +120,10 @@ class Options:
         group.add_argument(
             "--test", action="store_true",
             help="Run a simple smoke test against the github server")
+        group.add_argument(
+            "--version", "-V", action="version",
+            version=f"did {get_version()}",
+            help="Show program version and exit")
 
     def _prepare_arguments(self, arguments: Union[None, str, list[str]]) -> None:
         """ Prepare arguments (both direct and from command line) """
@@ -209,6 +223,11 @@ def main(arguments: Union[None, str, list[str]] = None
 
     with the list of all gathered stats objects.
     """
+    argv = _argv_list(arguments)
+    if "--version" in argv or "-V" in argv:
+        print(f"did {get_version()}")
+        raise SystemExit(0)
+
     config = None
     try:
         config = did.base.Config()

--- a/did/version.py
+++ b/did/version.py
@@ -1,0 +1,52 @@
+"""
+Version string for did.
+
+Uses :mod:`importlib.metadata` when the package is installed; falls back to
+parsing ``did.spec`` in a source checkout (same scheme as ``setup.py``).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def get_version() -> str:
+    """
+    Return did version (e.g. ``0.23.1``).
+
+    Prefer the installed distribution metadata; otherwise parse ``did.spec``.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+    except ImportError:  # pragma: no cover - Python < 3.8
+        from importlib_metadata import (  # type: ignore[import-not-found,no-redef]
+            PackageNotFoundError,
+            version,
+        )
+
+    try:
+        return version("did")
+    except PackageNotFoundError:
+        pass
+
+    parsed = _version_from_spec()
+    return parsed if parsed is not None else "0.0.0"
+
+
+def _version_from_spec() -> str | None:
+    """Parse ``Version`` and numeric ``Release`` from ``did.spec`` if found."""
+    here = Path(__file__).resolve().parent
+    for base in [here.parent, *here.parents]:
+        spec_path = base / "did.spec"
+        if not spec_path.is_file():
+            continue
+        text = spec_path.read_text(encoding="utf-8")
+        vm = re.search(r"^Version:\s*(.+)$", text, re.MULTILINE)
+        rm = re.search(r"^Release:\s*(\d+)", text, re.MULTILINE)
+        if not vm or not rm:
+            return None
+        ver = vm.group(1).strip()
+        rel = rm.group(1).strip()
+        return f"{ver}.{rel}"
+    return None

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -66,6 +66,25 @@ def test_invalid_date() -> None:
             did.cli.main(argument)
 
 
+def test_version_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    """ --version exits before config and prints a version line """
+    with pytest.raises(SystemExit) as exc:
+        did.cli.main(["--version"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out.strip()
+    assert out.startswith("did ")
+    assert len(out) > len("did ")
+
+
+def test_version_short_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    """ -V is an alias for --version """
+    with pytest.raises(SystemExit) as exc:
+        did.cli.main(["-V"])
+    assert exc.value.code == 0
+    out = capsys.readouterr().out.strip()
+    assert out.startswith("did ")
+
+
 def test_conflicting_options() -> None:
     """ Complain about conflicting options """
     did.base.Config(config=MINIMAL)

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,0 +1,12 @@
+# coding: utf-8
+""" Tests for did.version """
+
+import re
+
+from did.version import get_version
+
+
+def test_get_version_format() -> None:
+    """ Version string looks like N.N.N (matches did.spec / install metadata). """
+    ver = get_version()
+    assert re.match(r"^\d+\.\d+\.\d+$", ver), ver


### PR DESCRIPTION
Added --version / -V flag and did.version.get_version()
It exposes version via importlib.metadata when installed, else did.spec. Exits before config load so --version works without a config file and registered flag within --help. Tests and README updated.

Assisted-by: Claude