### PR TITLE
Fix KeyError when GitLab event data lacks target_id

### DIFF
--- a/did/plugins/gitlab.py
+++ b/did/plugins/gitlab.py
@@ -334,9 +334,11 @@ class Issue():
         self._body: Optional[str] = None
 
     def iid(self):
+        target_id = self.data.get('target_id')
+        if target_id is None:
+            return "unknown"
         issue = self.gitlabapi.get_project_issue(
-            self.data['project_id'], self.data['target_id'])
-
+            self.data['project_id'], target_id)
         if issue is not None:
             return issue['iid']
         return "unknown"
@@ -345,9 +347,13 @@ class Issue():
     def body(self) -> str:
         """Get full issue description (lazy-loaded)"""
         if self._body is None:
-            issue_data = self.gitlabapi.get_project_issue(
-                self.data['project_id'], self.data['target_id'])
-            self._body = issue_data.get('description', '') if issue_data else ''
+            target_id = self.data.get('target_id')
+            if target_id is None:
+                self._body = ''
+            else:
+                issue_data = self.gitlabapi.get_project_issue(
+                    self.data['project_id'], target_id)
+                self._body = issue_data.get('description', '') if issue_data else ''
         return self._body
 
     def __str__(self):
@@ -397,19 +403,25 @@ class MergeRequest(Issue):
 
     def __init__(self, data, parent, set_id=None):
         if set_id is None:
-            merge_request = parent.gitlab.get_project_mr(
-                data['project_id'], data['target_id'])
-            if merge_request is not None:
-                set_id = merge_request['iid']
+            target_id = data.get('target_id')
+            if target_id is not None:
+                merge_request = parent.gitlab.get_project_mr(
+                    data['project_id'], target_id)
+                if merge_request is not None:
+                    set_id = merge_request['iid']
         super().__init__(data, parent, set_id)
 
     @property
     def body(self) -> str:
         """Get full MR description (lazy-loaded)"""
         if self._body is None:
-            mr_data = self.gitlabapi.get_project_mr(
-                self.data['project_id'], self.data['target_id'])
-            self._body = mr_data.get('description', '') if mr_data else ''
+            target_id = self.data.get('target_id')
+            if target_id is None:
+                self._body = ''
+            else:
+                mr_data = self.gitlabapi.get_project_mr(
+                    self.data['project_id'], target_id)
+                self._body = mr_data.get('description', '') if mr_data else ''
         return self._body
 
 

--- a/tests/unit/plugins/test_gitlab.py
+++ b/tests/unit/plugins/test_gitlab.py
@@ -3,12 +3,14 @@
 
 import logging
 import os
+from unittest.mock import MagicMock
 
 import pytest
 from _pytest.logging import LogCaptureFixture
 
 import did.base
 import did.cli
+from did.plugins.gitlab import Issue, MergedRequest, MergeRequest
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Constants
@@ -209,3 +211,58 @@ def test_gitlab_config_disabled_ssl_verify():
 ssl_verify = False
 """)
     did.cli.main(INTERVAL)
+
+
+def _make_parent(full_message=True):
+    """ Build a minimal mock GitLabStats parent """
+    parent = MagicMock()
+    parent.gitlab.url = "https://gitlab.com"
+    parent.gitlab.get_project.return_value = {
+        "path_with_namespace": "user/project"}
+    parent.options.full_message = full_message
+    parent.options.format = "text"
+    return parent
+
+
+def test_issue_str_missing_target_id():
+    """ Issue.__str__ with full_message should not raise when
+    target_id is absent """
+    parent = _make_parent()
+    data = {
+        "project_id": 1,
+        "target_title": "Some issue",
+        "target_type": "Issue",
+        }
+    issue = Issue(data, parent)
+    result = str(issue)
+    assert "Some issue" in result
+
+
+def test_merge_request_str_missing_target_id():
+    """ MergeRequest.__str__ with full_message should not raise when
+    target_id is absent """
+    parent = _make_parent()
+    data = {
+        "project_id": 1,
+        "target_title": "Some MR",
+        "target_type": "MergeRequest",
+        }
+    mr = MergeRequest(data, parent, set_id=42)
+    result = str(mr)
+    assert "Some MR" in result
+
+
+def test_merged_request_str_full_message():
+    """ MergedRequest.__str__ with full_message should not raise when
+    target_id is absent from raw MR data """
+    parent = _make_parent()
+    data = {
+        "id": 99,
+        "iid": 4,
+        "project_id": 1,
+        "title": "Update README.md",
+        "description": "Fixes the readme",
+        }
+    mr = MergedRequest(data, parent)
+    result = str(mr)
+    assert "Update README.md" in result


### PR DESCRIPTION
## Problem

Using `--full-message` with a GitLab config crashes with:

    KeyError: 'target_id'

at `Issue.body` and `MergeRequest.body`.

## Fix

Use `.get('target_id')` in `Issue.iid()`, `Issue.body`,
`MergeRequest.__init__`, and `MergeRequest.body` so that events or
objects missing `target_id` degrade gracefully instead of raising.

Add unit tests covering `Issue`, `MergeRequest`, and `MergedRequest`
with missing `target_id` and `--full-message` enabled.