### PR TITLE
fix(zammad): handle flat list response from search API

### DIFF
--- a/did/plugins/zammad.py
+++ b/did/plugins/zammad.py
@@ -60,11 +60,16 @@ class Zammad():
                 f"Zammad search on {self.url} failed.") from error
 
     def search(self, query: str) -> dict:
-        result = self.perform_search(query)["assets"]
-        try:
-            result = result["Ticket"]
-        except KeyError:
-            result = {}
+        result = self.perform_search(query)
+        if isinstance(result, list):
+            # Newer Zammad API returns a flat list of ticket objects
+            result = {str(ticket["id"]): ticket for ticket in result}
+        else:
+            result = result["assets"]
+            try:
+                result = result["Ticket"]
+            except KeyError:
+                result = {}
         log.debug("Result: %s fetched", listed(len(result), "item"))
         log.data(pretty(result))
         return result


### PR DESCRIPTION
## Summary

Newer Zammad instances return a flat list of ticket objects from the
search endpoint instead of the `{"assets": {"Ticket": {...}}}` enveloppe.

## Fix

Detect the response type:
- list → build `{str(id): ticket}` dict directly
- dict → existing `assets.Ticket` unwrap path

Both paths produce the same structure consumed by `TicketsUpdated.fetch()`.

## Traceback

```
Traceback (most recent call last):
  ...
  File ".../did/plugins/zammad.py", line 114, in fetch
    for _, ticket in self.parent.zammad.search(query).items():
                     ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
  File ".../did/plugins/zammad.py", line 63, in search
    result = self.perform_search(query)["assets"]
             ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
TypeError: list indices must be integers or slices, not str
```

Tested against a Zammad instance runing the newer API format, confirmed working.