### PR TITLE
Add missing runtime dependencies to the pylint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,23 @@ repos:
             "-sn", # Don't display the score
             "--rcfile=.pylintrc", # Link to config file
           ]
+        additional_dependencies:
+          [
+            bodhi-client,
+            feedparser,
+            google-api-python-client,
+            gssapi,
+            koji,
+            nitrate,
+            oauth2client,
+            pytest,
+            python-bugzilla,
+            python-dateutil,
+            requests,
+            requests-gssapi,
+            setuptools,
+            tenacity,
+          ]
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1


### PR DESCRIPTION
The pylint `pre-commit` hook reports `import-error` across the plugin
modules. `import-error` is not in the `disable=` list in `.pylintrc`, and
pre-commit runs each hook in its own isolated virtualenv, so the
`init-hook` `sys.path` extension only ever sees the hook's own venv.
Without these dependencies pylint cannot resolve `feedparser`, `koji`,
`nitrate`, `bodhi-client` and friends, and reports one error per plugin.

This mirrors the list the mypy hook directly below already carries. The
difference between the two is that pylint needs the real packages where
mypy wants the stubs, hence `requests` and `python-dateutil` here instead
of `types-requests` and `types-python-dateutil`.

Split out of #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
