### PR TITLE
Clean up error output: color reset sequence and stat failure message

### DIFF
--- a/did/stats.py
+++ b/did/stats.py
@@ -179,7 +179,7 @@ class StatsGroup(Stats, metaclass=StatsGroupPlugin):
                 try:
                     f.result()
                 except did.base.ReportError as error:
-                    log.error("Skipping %s due to %s", f, error)
+                    log.error("%s", error)
                     sys.stdout.flush()
                     sys.stderr.flush()
 

--- a/did/utils.py
+++ b/did/utils.py
@@ -521,7 +521,7 @@ def color(
     light_code = (1 if light else 0)
     # Starting and finishing sequence
     start = f"\033[{light_code}{text_color_code}{background_code}m"
-    finish = "\033[1;m"
+    finish = "\033[0m"
     return "".join([start, text, finish])
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -238,7 +238,7 @@ def test_color_function_exists() -> None:
     # No color sets
     res = did.utils.color(
         "text", text_color=None, background=None, light=False, enabled=True)
-    assert res == "\033[0mtext\033[1;m"
+    assert res == "\033[0mtext\033[0m"
     # Disabled
     res = did.utils.color(
         "text", text_color=None, background=None, light=False, enabled=False)
@@ -256,11 +256,11 @@ def test_color_function_exists() -> None:
     # Known color
     res = did.utils.color(
         "text", text_color="red", background=None, light=False, enabled=True)
-    assert res == "\033[0;31mtext\033[1;m"
+    assert res == "\033[0;31mtext\033[0m"
     # Light version
     res = did.utils.color(
         "text", text_color="red", background=None, light=True, enabled=True)
-    assert res == "\033[1;31mtext\033[1;m"
+    assert res == "\033[1;31mtext\033[0m"
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  strtobool


### PR DESCRIPTION
Two fixes

### `did/utils.py`

The reset sequence emitted by `color()` was `\033[1;m`, where it should be `\033[0m`.
The three `tests/unit/test_utils.py` assertions follow from the change.

### `did/stats.py`

The failure path logged `Skipping %s due to %s` with a
`concurrent.futures.Future` as the first argument, so it rendered a repr:

```
Skipping <Future at 0x1063a4830 state=finished raised ReportError> due to Unable to fetch token
```

This change keeps only the last part, error text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
